### PR TITLE
[fix] 탈퇴 회원 이름 null로 변경

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserRepository.java
@@ -18,7 +18,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Modifying
     @Transactional
-    @Query("UPDATE User u SET u.name = '(알 수 없음)', u.email = CONCAT('deleted_', u.id, '@chungbazi.com') WHERE u.id = :userId")
+    @Query("UPDATE User u SET u.name = NULL , u.email = CONCAT('deleted_', u.id, '@chungbazi.com') WHERE u.id = :userId")
     void anonymizeUser(@Param("userId") Long userId);
 
     @Query("SELECT DISTINCT u FROM User u " +


### PR DESCRIPTION
## 연관 이슈

close #4

<br/>

## 개요

현재 애플리케이션 단에 user name에 unique제약이 있는데, 탈퇴 시 회원 이름을 (알 수 없음) 값으로 넣고있어, duplicate문제가 발생했습니다.

따라서 탈퇴 시 회원 이름을 null로 변경하도록 수정했습니다

<br/>

## ✅ 작업 내용

- 탈퇴 회원 이름 null로 변경


<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
