### PR TITLE
[bug] 정책 삭제 시, 관련 카트도 삭제

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/cart/entity/Cart.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/cart/entity/Cart.java
@@ -30,7 +30,7 @@ public class Cart extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "policy_id")
+    @JoinColumn(name = "policy_id", nullable = false)
     private Policy policy;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/chungbazi/chungbazi_be/domain/cart/repository/CartRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/cart/repository/CartRepository.java
@@ -38,14 +38,7 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
     @Query("DELETE FROM Cart c WHERE c.policy.id IN :policyIds")
     void deleteByPolicyIdIn(@Param("policyIds") List<Long> policyIds);
 
-    @Query("SELECT c FROM Cart c WHERE c.policy.id IN :expiredPolicyIds")
-    List<Cart> findAllByPolicyIdIn(@Param("expiredPolicyIds") List<Long> expiredPolicyIds);
+    @Query("SELECT c.id FROM Cart c WHERE c.policy.id IN :expiredPolicyIds")
+    List<Long> findAllByPolicyIdIn(@Param("expiredPolicyIds") List<Long> expiredPolicyIds);
 
-    @Modifying
-    @Query("UPDATE Cart c SET c.policy = null WHERE c.policy.id IN :policyIds")
-    void nullifyPolicyByPolicyIds(@Param("policyIds") List<Long> policyIds);
-
-    @Modifying
-    @Query("DELETE FROM Cart c WHERE c.policy.id IN :policyIds")
-    void deleteAllByPolicyIdIn(List<Long> expiredPolicyIds);
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/cart/repository/CartRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/cart/repository/CartRepository.java
@@ -44,4 +44,8 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
     @Modifying
     @Query("UPDATE Cart c SET c.policy = null WHERE c.policy.id IN :policyIds")
     void nullifyPolicyByPolicyIds(@Param("policyIds") List<Long> policyIds);
+
+    @Modifying
+    @Query("DELETE FROM Cart c WHERE c.policy.id IN :policyIds")
+    void deleteAllByPolicyIdIn(List<Long> expiredPolicyIds);
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/cart/service/CartService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/cart/service/CartService.java
@@ -140,19 +140,13 @@ public class CartService {
     }
 
     @Transactional
-    public void nullifyPolicyInCart(List<Long> expiredPolicyIds) {
+    public void deletePolicyInCart(List<Long> expiredPolicyIds) {
         // 해당 policyIds를 가진 모든 cart 찾기
-        List<Cart> carts = cartRepository.findAllByPolicyIdIn(expiredPolicyIds);
-
-        if (carts.isEmpty()) {
+        if (expiredPolicyIds == null || expiredPolicyIds.isEmpty()) {
             return;
         }
 
-        // 정책 참조 제거
-        cartRepository.nullifyPolicyByPolicyIds(expiredPolicyIds);
-
-
-        cartRepository.saveAll(carts);
+        cartRepository.deleteAllByPolicyIdIn(expiredPolicyIds);
     }
 
     /*

--- a/src/main/java/chungbazi/chungbazi_be/domain/cart/service/CartService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/cart/service/CartService.java
@@ -7,6 +7,7 @@ import chungbazi.chungbazi_be.domain.cart.dto.CartResponseDTO;
 import chungbazi.chungbazi_be.domain.cart.entity.Cart;
 import chungbazi.chungbazi_be.domain.cart.repository.CartRepository;
 import chungbazi.chungbazi_be.domain.document.repository.CalendarDocumentRepository;
+import chungbazi.chungbazi_be.domain.document.service.CalendarDocumentService;
 import chungbazi.chungbazi_be.domain.notification.service.NotificationService;
 import chungbazi.chungbazi_be.domain.policy.dto.PolicyCalendarResponse;
 import chungbazi.chungbazi_be.domain.policy.entity.Category;
@@ -146,7 +147,9 @@ public class CartService {
             return;
         }
 
-        cartRepository.deleteAllByPolicyIdIn(expiredPolicyIds);
+        calendarDocumentRepository.deleteByPolicyIdIn(expiredPolicyIds);
+
+        cartRepository.deleteByPolicyIdIn(expiredPolicyIds);
     }
 
     /*

--- a/src/main/java/chungbazi/chungbazi_be/domain/document/repository/CalendarDocumentRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/document/repository/CalendarDocumentRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CalendarDocumentRepository extends JpaRepository<CalendarDocument, Long> {
     void deleteByIdIn(List<Long> deleteIds);
@@ -14,10 +15,14 @@ public interface CalendarDocumentRepository extends JpaRepository<CalendarDocume
 
     void deleteByCart_IdIn(List<Long> deleteList);
 
-    void deleteByCart(Cart cart);
-
     @Modifying
     @Query("DELETE FROM CalendarDocument cd " +
             "WHERE cd.cart.id IN :cartIds")
     void deleteByCartIdIn(List<Long> cartIds);
+
+
+    @Modifying
+    @Query("DELETE FROM CalendarDocument cd " +
+            "WHERE cd.cart.id IN (SELECT c.id FROM Cart c WHERE c.policy.id IN :policyIds)")
+    void deleteByPolicyIdIn(@Param("policyIds") List<Long> policyIds);
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/document/service/CalendarDocumentService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/document/service/CalendarDocumentService.java
@@ -87,8 +87,5 @@ public class CalendarDocumentService {
         return calendarDocumentRepository.findAllByCart_Id(cartId);
     }
 
-    @Transactional
-    public void deleteByCartIdIn(List<Long> cartIds) {
-        calendarDocumentRepository.deleteByCartIdIn(cartIds);
-    }
+
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
@@ -225,7 +225,7 @@ public class PolicyService {
         }
 
         // Cart와의 연관관계 제거
-        cartService.nullifyPolicyInCart(expiredPolicyIds);
+        cartService.deletePolicyInCart(expiredPolicyIds);
 
         // Policy 삭제
         long deletedPolicies = policyRepository.deleteByIdIn(expiredPolicyIds);

--- a/src/main/java/chungbazi/chungbazi_be/global/scheduler/PolicyScheduler.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/scheduler/PolicyScheduler.java
@@ -32,7 +32,7 @@ public class PolicyScheduler {
     }
 
     //마감기한 지난 정책들 DB에서 삭제
-    @Scheduled(cron = "0 2 23  * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 1 0  * * *", zone = "Asia/Seoul")
     public void deletePolicy() {
 
         long deletedCount = policyService.deleteExpiredPolicies();

--- a/src/main/java/chungbazi/chungbazi_be/global/scheduler/PolicyScheduler.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/scheduler/PolicyScheduler.java
@@ -32,7 +32,7 @@ public class PolicyScheduler {
     }
 
     //마감기한 지난 정책들 DB에서 삭제
-    @Scheduled(cron = "0 1 0  * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 2 23  * * *", zone = "Asia/Seoul")
     public void deletePolicy() {
 
         long deletedCount = policyService.deleteExpiredPolicies();


### PR DESCRIPTION
## 개요

기존 로직에서는 정책이 db에서 삭제될 경우, cart에 policy_id를 null로 설정했으나, 그럴 경우 각 조회 api에서 NPE 에러가 발생하여, cart도 같이 삭제되도록 수정했습니다

<br/>

## ✅ 작업 내용

- 정책 마감 스케줄링에서 정책 삭제 시, 관련 카트도 삭제

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 장바구니와 정책 간의 데이터 무결성을 강화하여 정책 없는 장바구니 생성을 방지합니다.
  * 만료된 정책 삭제 시 관련 장바구니를 자동으로 정리하여 시스템 데이터 정합성을 개선합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->