### PR TITLE
[hotfix] 안읽은 알림 개수 조회, 정책 디데이 관련 수정사항

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/cart/converter/CartConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/cart/converter/CartConverter.java
@@ -15,7 +15,7 @@ public class CartConverter {
         if (policy.getEndDate() == null) {
             dDay = null;
         } else {
-            dDay = (int) ChronoUnit.DAYS.between(policy.getEndDate(), LocalDate.now());
+            dDay = (int) ChronoUnit.DAYS.between(LocalDate.now(), policy.getEndDate());
         }
         return CartResponseDTO.CartPolicy.builder()
                 .name(policy.getName())

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
@@ -78,11 +78,9 @@ public class NotificationService {
     }
 
     //안 읽은 알림이 있는지 검사하는 로직
-    public boolean isReadAllNotification(){
-        User user=userHelper.getAuthenticatedUser();
-
+    public boolean isReadAllNotification(User user) {
         return user.getNotificationList().stream()
-                .anyMatch(notification -> !notification.isRead());
+                .allMatch(Notification::isRead);
     }
 
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/dto/PolicyCalendarDetailResponse.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/dto/PolicyCalendarDetailResponse.java
@@ -33,7 +33,7 @@ public class PolicyCalendarDetailResponse {
         if (policy.getEndDate() == null) {
             dDay = null;
         } else {
-            dDay = (int) ChronoUnit.DAYS.between(policy.getEndDate(), LocalDate.now());
+            dDay = (int) ChronoUnit.DAYS.between(LocalDate.now(), policy.getEndDate());
         }
 
         List<DocumentResponseDTO.DocumentDTO> documentDTOs = documents.stream()

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
@@ -171,7 +171,7 @@ public class PolicyService {
         }
 
         //안 읽은 알림 개수 & 유저 관심분야
-        boolean isReadAllNotifications=notificationService.isReadAllNotification();
+        boolean isReadAllNotifications=notificationService.isReadAllNotification(user);
         Set<Category> userCategories = getUserInterests(user);
 
         return PolicyRecommendResponse.of(policies, userCategories, hasNext, isReadAllNotifications, user.getName(), nextCursor);


### PR DESCRIPTION
## 개요

프론트의 요청으로 안읽은 알림 개수 조회, 정책 디데이 관련 수정했습니다.

<br/>

## ✅ 작업 내용

- 안읽은 알림 개수 조회
    - 로직이 반대로 되어있어 수정했습니다.
    - 추후, 따로 API로 빼내어 리팩토링할 예정입니다.

- 정책 디데이 관련 수정
    - 이전에 정책 관련 리팩토링을 하면서 정책 조회 관련 API에서 디데이를 양수로 반환하는 방식으로 바뀌었는데, 캘린더 정책 조회, 장바구니 정책 조회에서는 음수로 반환되고있어 이에 대해 수정했습니다.

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 정책 마감일 계산 로직을 수정했습니다. 남은 날짜(D-Day) 계산이 더 정확하게 반영됩니다.
  * 알림 읽음 상태 확인 로직을 개선했습니다. 사용자 알림 상태가 올바르게 평가됩니다.
  * 정책 추천 기능에서 사용자 인증 정보가 올바르게 전달되도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->