### PR TITLE
[Feat] 홈 화면 API 구현

### DIFF
--- a/src/main/java/com/chungbazi/server/domain/policy/api/HomeController.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/HomeController.java
@@ -38,10 +38,11 @@ public class HomeController implements HomeDocs {
     @GetMapping("/policies/recent-viewed")
     public CommonResponse<PolicyListResponse> getRecentViewedPolicies(
             @CurrentUser User user,
+            @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "5") @Min(1) @Max(5) int size
     ) {
         return CommonResponse.onSuccess(
-                homePolicyService.getRecentViewedPolicies(user, size)
+                homePolicyService.getRecentViewedPolicies(user, cursor, size)
         );
     }
 

--- a/src/main/java/com/chungbazi/server/domain/policy/api/HomeController.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/HomeController.java
@@ -1,6 +1,7 @@
 package com.chungbazi.server.domain.policy.api;
 
 import com.chungbazi.server.domain.policy.api.docs.HomeDocs;
+import com.chungbazi.server.domain.policy.api.dto.response.HomePolicyResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
 import com.chungbazi.server.domain.policy.application.HomePolicyService;
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
@@ -24,6 +25,25 @@ import org.springframework.web.bind.annotation.RestController;
 public class HomeController implements HomeDocs {
 
     private final HomePolicyService homePolicyService;
+
+    @Override
+    @GetMapping
+    public CommonResponse<HomePolicyResponse> getHomePolicies(@CurrentUser User user) {
+        return CommonResponse.onSuccess(
+                homePolicyService.getHomePolicies(user)
+        );
+    }
+
+    @Override
+    @GetMapping("/policies/recent-viewed")
+    public CommonResponse<PolicyListResponse> getRecentViewedPolicies(
+            @CurrentUser User user,
+            @RequestParam(defaultValue = "5") @Min(1) @Max(5) int size
+    ) {
+        return CommonResponse.onSuccess(
+                homePolicyService.getRecentViewedPolicies(user, size)
+        );
+    }
 
     @Override
     @GetMapping("/policies")

--- a/src/main/java/com/chungbazi/server/domain/policy/api/docs/HomeDocs.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/docs/HomeDocs.java
@@ -1,6 +1,7 @@
 package com.chungbazi.server.domain.policy.api.docs;
 
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
+import com.chungbazi.server.domain.policy.api.dto.response.HomePolicyResponse;
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
 import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
 import com.chungbazi.server.domain.user.domain.User;
@@ -17,6 +18,45 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "[Home]", description = "홈 정책 관련 API")
 public interface HomeDocs {
+
+    @Operation(
+            summary = "홈 화면 정책 섹션 조회 API",
+            description = """
+                    홈 화면에 필요한 정책 섹션을 한 번에 조회합니다.
+                    각 섹션은 최대 5개 정책을 반환합니다.
+
+                    - 최근 본 정책: 현재 사용자가 최근 조회한 순서
+                    - 인기 정책: 인기도 순
+                    - 마감 임박 정책: 마감일이 가까운 순
+                    - 최신 정책: 최신 등록 순
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "홈 화면 정책 섹션 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    CommonResponse<HomePolicyResponse> getHomePolicies(
+            @CurrentUser User user
+    );
+
+    @Operation(
+            summary = "최근 본 정책 목록 조회 API",
+            description = """
+                    현재 사용자가 최근 본 정책을 최근 조회한 순서대로 조회합니다.
+                    같은 정책을 여러 번 본 경우 가장 최근 조회 기록을 기준으로 한 번만 노출합니다.
+
+                    - `size`: 조회할 정책 수(기본 5, 최대 5)
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "최근 본 정책 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    CommonResponse<PolicyListResponse> getRecentViewedPolicies(
+            @CurrentUser User user,
+            @Parameter(description = "조회 개수", example = "5")
+            @RequestParam(defaultValue = "5") @Min(1) @Max(5) int size
+    );
 
     @Operation(
             summary = "분야별 정책 목록 조회 API",

--- a/src/main/java/com/chungbazi/server/domain/policy/api/docs/HomeDocs.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/docs/HomeDocs.java
@@ -45,6 +45,7 @@ public interface HomeDocs {
                     현재 사용자가 최근 본 정책을 최근 조회한 순서대로 조회합니다.
                     같은 정책을 여러 번 본 경우 가장 최근 조회 기록을 기준으로 한 번만 노출합니다.
 
+                    - `cursor`: 최초 요청에서는 생략하고, 다음 요청부터 응답의 `nextCursor`를 전달합니다.
                     - `size`: 조회할 정책 수(기본 5, 최대 5)
                     """
     )
@@ -54,6 +55,8 @@ public interface HomeDocs {
     })
     CommonResponse<PolicyListResponse> getRecentViewedPolicies(
             @CurrentUser User user,
+            @Parameter(description = "이전 응답에서 받은 다음 페이지 커서")
+            @RequestParam(required = false) String cursor,
             @Parameter(description = "조회 개수", example = "5")
             @RequestParam(defaultValue = "5") @Min(1) @Max(5) int size
     );

--- a/src/main/java/com/chungbazi/server/domain/policy/api/dto/response/HomePolicyResponse.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/dto/response/HomePolicyResponse.java
@@ -1,0 +1,23 @@
+package com.chungbazi.server.domain.policy.api.dto.response;
+
+import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse.PolicySummary;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "홈 화면 정책 섹션 응답")
+public record HomePolicyResponse(
+        @Schema(description = "최근 본 정책 목록")
+        List<PolicySummary> recentViewedPolicies,
+
+        @Schema(description = "인기 정책 목록")
+        List<PolicySummary> popularPolicies,
+
+        @Schema(description = "마감 임박 정책 목록")
+        List<PolicySummary> upcomingDeadlinePolicies,
+
+        @Schema(description = "최신 정책 목록")
+        List<PolicySummary> latestPolicies
+) {
+}

--- a/src/main/java/com/chungbazi/server/domain/policy/api/dto/response/PolicyListResponse.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/dto/response/PolicyListResponse.java
@@ -34,13 +34,9 @@ public record PolicyListResponse(
             String nextCursor,
             boolean hasNext
     ) {
-        List<PolicySummary> summaries = policies.stream()
-                .map(policy -> PolicySummary.from(policy, likedPolicyIds))
-                .toList();
-
         return PolicyListResponse.builder()
                 .totalCount(totalCount)
-                .policies(summaries)
+                .policies(PolicySummary.from(policies, likedPolicyIds))
                 .nextCursor(nextCursor)
                 .hasNext(hasNext)
                 .build();
@@ -83,6 +79,12 @@ public record PolicyListResponse(
                     .viewCount(policy.getViewCount())
                     .liked(likedPolicyIds.contains(policy.getId()))
                     .build();
+        }
+
+        public static List<PolicySummary> from(List<Policy> policies, Set<Long> likedPolicyIds) {
+            return policies.stream()
+                    .map(policy -> PolicySummary.from(policy, likedPolicyIds))
+                    .toList();
         }
 
         private static String formatDDay(Policy policy) {

--- a/src/main/java/com/chungbazi/server/domain/policy/application/HomePolicyService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/HomePolicyService.java
@@ -4,7 +4,10 @@ import com.chungbazi.server.domain.policy.api.dto.response.HomePolicyResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
 import com.chungbazi.server.domain.policy.application.cursor.PolicyCursor;
 import com.chungbazi.server.domain.policy.application.cursor.PolicyCursorParser;
+import com.chungbazi.server.domain.policy.application.cursor.RecentViewedPolicyCursor;
+import com.chungbazi.server.domain.policy.application.cursor.RecentViewedPolicyCursorParser;
 import com.chungbazi.server.domain.policy.domain.entity.Policy;
+import com.chungbazi.server.domain.policy.domain.entity.RecentViewedPolicy;
 import com.chungbazi.server.domain.policy.domain.repository.RecentViewedPolicyRepository;
 import com.chungbazi.server.domain.policy.domain.repository.policyRepository.PolicyRepository;
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
@@ -40,13 +43,10 @@ public class HomePolicyService {
         LocalDate today = LocalDate.now(SERVICE_ZONE_ID);
         PageRequest sectionPageRequest = PageRequest.of(0, HOME_SECTION_SIZE);
 
-        List<Policy> recentViewedPolicies = recentViewedPolicyRepository.findRecentViewedPolicies(
-                user.getId(),
-                RecruitmentStatus.CLOSED,
-                user.getSidoCode(),
-                user.getSigunguCode(),
-                sectionPageRequest
-        );
+        List<Policy> recentViewedPolicies = fetchRecentViewedPolicies(user, null, sectionPageRequest)
+                .stream()
+                .map(RecentViewedPolicy::getPolicy)
+                .toList();
         List<Policy> popularPolicies = fetchPopularPolicies(
                 user,
                 null,
@@ -85,13 +85,12 @@ public class HomePolicyService {
                 .build();
     }
 
-    public PolicyListResponse getRecentViewedPolicies(User user, int size) {
-        List<Policy> fetchedPolicies = recentViewedPolicyRepository.findRecentViewedPolicies(
-                user.getId(),
-                RecruitmentStatus.CLOSED,
-                user.getSidoCode(),
-                user.getSigunguCode(),
-                PageRequest.of(0, size)
+    public PolicyListResponse getRecentViewedPolicies(User user, String cursor, int size) {
+        RecentViewedPolicyCursor decodedCursor = RecentViewedPolicyCursorParser.decode(cursor);
+        List<RecentViewedPolicy> fetchedRecentViewedPolicies = fetchRecentViewedPolicies(
+                user,
+                decodedCursor,
+                PageRequest.of(0, size + 1)
         );
         long totalCount = recentViewedPolicyRepository.countRecentViewedPolicies(
                 user.getId(),
@@ -100,12 +99,44 @@ public class HomePolicyService {
                 user.getSigunguCode()
         );
 
-        return policyListResponseAssembler.assemble(
-                user,
-                PolicySortType.LATEST,
-                fetchedPolicies,
-                totalCount,
-                size
+        boolean hasNext = fetchedRecentViewedPolicies.size() > size;
+        List<RecentViewedPolicy> recentViewedPolicies = hasNext
+                ? fetchedRecentViewedPolicies.subList(0, size)
+                : fetchedRecentViewedPolicies;
+        List<Policy> policies = recentViewedPolicies.stream()
+                .map(RecentViewedPolicy::getPolicy)
+                .toList();
+        Set<Long> likedPolicyIds = policyListResponseAssembler.findLikedPolicyIds(user.getId(), policies);
+        String nextCursor = hasNext
+                ? RecentViewedPolicyCursorParser.encode(recentViewedPolicies.getLast())
+                : null;
+
+        return PolicyListResponse.of(totalCount, policies, likedPolicyIds, nextCursor, hasNext);
+    }
+
+    private List<RecentViewedPolicy> fetchRecentViewedPolicies(
+            User user,
+            RecentViewedPolicyCursor cursor,
+            PageRequest pageRequest
+    ) {
+        if (cursor != null) {
+            return recentViewedPolicyRepository.findRecentViewedPoliciesAfter(
+                    user.getId(),
+                    RecruitmentStatus.CLOSED,
+                    user.getSidoCode(),
+                    user.getSigunguCode(),
+                    cursor.viewedAt(),
+                    cursor.policyId(),
+                    pageRequest
+            );
+        }
+
+        return recentViewedPolicyRepository.findRecentViewedPolicies(
+                user.getId(),
+                RecruitmentStatus.CLOSED,
+                user.getSidoCode(),
+                user.getSigunguCode(),
+                pageRequest
         );
     }
 

--- a/src/main/java/com/chungbazi/server/domain/policy/application/HomePolicyService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/HomePolicyService.java
@@ -1,9 +1,11 @@
 package com.chungbazi.server.domain.policy.application;
 
+import com.chungbazi.server.domain.policy.api.dto.response.HomePolicyResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
 import com.chungbazi.server.domain.policy.application.cursor.PolicyCursor;
 import com.chungbazi.server.domain.policy.application.cursor.PolicyCursorParser;
 import com.chungbazi.server.domain.policy.domain.entity.Policy;
+import com.chungbazi.server.domain.policy.domain.repository.RecentViewedPolicyRepository;
 import com.chungbazi.server.domain.policy.domain.repository.policyRepository.PolicyRepository;
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
 import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
@@ -14,9 +16,9 @@ import com.chungbazi.server.domain.user.domain.User;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -27,10 +29,85 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class HomePolicyService {
 
+    private static final int HOME_SECTION_SIZE = 5;
     private static final ZoneId SERVICE_ZONE_ID = ZoneId.of("Asia/Seoul");
 
     private final PolicyRepository policyRepository;
+    private final RecentViewedPolicyRepository recentViewedPolicyRepository;
     private final PolicyListResponseAssembler policyListResponseAssembler;
+
+    public HomePolicyResponse getHomePolicies(User user) {
+        LocalDate today = LocalDate.now(SERVICE_ZONE_ID);
+        PageRequest sectionPageRequest = PageRequest.of(0, HOME_SECTION_SIZE);
+
+        List<Policy> recentViewedPolicies = recentViewedPolicyRepository.findRecentViewedPolicies(
+                user.getId(),
+                RecruitmentStatus.CLOSED,
+                user.getSidoCode(),
+                user.getSigunguCode(),
+                sectionPageRequest
+        );
+        List<Policy> popularPolicies = fetchPopularPolicies(
+                user,
+                null,
+                null,
+                sectionPageRequest
+        );
+        List<Policy> upcomingDeadlinePolicies = fetchUpcomingDeadlinePolicies(
+                user,
+                null,
+                null,
+                today,
+                sectionPageRequest
+        );
+        List<Policy> latestPolicies = fetchLatestPolicies(
+                user,
+                null,
+                null,
+                sectionPageRequest
+        );
+
+        List<Policy> homePolicies = Stream.of(
+                        recentViewedPolicies,
+                        popularPolicies,
+                        upcomingDeadlinePolicies,
+                        latestPolicies
+                )
+                .flatMap(List::stream)
+                .toList();
+        Set<Long> likedPolicyIds = policyListResponseAssembler.findLikedPolicyIds(user.getId(), homePolicies);
+
+        return HomePolicyResponse.builder()
+                .recentViewedPolicies(policyListResponseAssembler.summarize(recentViewedPolicies, likedPolicyIds))
+                .popularPolicies(policyListResponseAssembler.summarize(popularPolicies, likedPolicyIds))
+                .upcomingDeadlinePolicies(policyListResponseAssembler.summarize(upcomingDeadlinePolicies, likedPolicyIds))
+                .latestPolicies(policyListResponseAssembler.summarize(latestPolicies, likedPolicyIds))
+                .build();
+    }
+
+    public PolicyListResponse getRecentViewedPolicies(User user, int size) {
+        List<Policy> fetchedPolicies = recentViewedPolicyRepository.findRecentViewedPolicies(
+                user.getId(),
+                RecruitmentStatus.CLOSED,
+                user.getSidoCode(),
+                user.getSigunguCode(),
+                PageRequest.of(0, size)
+        );
+        long totalCount = recentViewedPolicyRepository.countRecentViewedPolicies(
+                user.getId(),
+                RecruitmentStatus.CLOSED,
+                user.getSidoCode(),
+                user.getSigunguCode()
+        );
+
+        return policyListResponseAssembler.assemble(
+                user,
+                PolicySortType.LATEST,
+                fetchedPolicies,
+                totalCount,
+                size
+        );
+    }
 
     public PolicyListResponse getPolicies(
             User user,

--- a/src/main/java/com/chungbazi/server/domain/policy/application/PolicyListResponseAssembler.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/PolicyListResponseAssembler.java
@@ -48,9 +48,7 @@ public class PolicyListResponseAssembler {
     }
 
     public List<PolicySummary> summarize(List<Policy> policies, Set<Long> likedPolicyIds) {
-        return policies.stream()
-                .map(policy -> PolicySummary.from(policy, likedPolicyIds))
-                .toList();
+        return PolicySummary.from(policies, likedPolicyIds);
     }
 
     public Set<Long> findLikedPolicyIds(Long userId, List<Policy> policies) {

--- a/src/main/java/com/chungbazi/server/domain/policy/application/PolicyListResponseAssembler.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/PolicyListResponseAssembler.java
@@ -1,6 +1,7 @@
 package com.chungbazi.server.domain.policy.application;
 
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
+import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse.PolicySummary;
 import com.chungbazi.server.domain.policy.application.cursor.PolicyCursorParser;
 import com.chungbazi.server.domain.policy.domain.entity.Policy;
 import com.chungbazi.server.domain.policy.domain.repository.PolicyLikeRepository;
@@ -46,7 +47,13 @@ public class PolicyListResponseAssembler {
         );
     }
 
-    private Set<Long> findLikedPolicyIds(Long userId, List<Policy> policies) {
+    public List<PolicySummary> summarize(List<Policy> policies, Set<Long> likedPolicyIds) {
+        return policies.stream()
+                .map(policy -> PolicySummary.from(policy, likedPolicyIds))
+                .toList();
+    }
+
+    public Set<Long> findLikedPolicyIds(Long userId, List<Policy> policies) {
         if (policies.isEmpty()) {
             return Set.of();
         }

--- a/src/main/java/com/chungbazi/server/domain/policy/application/cursor/RecentViewedPolicyCursor.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/cursor/RecentViewedPolicyCursor.java
@@ -1,0 +1,9 @@
+package com.chungbazi.server.domain.policy.application.cursor;
+
+import java.time.LocalDateTime;
+
+public record RecentViewedPolicyCursor(
+        LocalDateTime viewedAt,
+        Long policyId
+) {
+}

--- a/src/main/java/com/chungbazi/server/domain/policy/application/cursor/RecentViewedPolicyCursorParser.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/cursor/RecentViewedPolicyCursorParser.java
@@ -1,0 +1,56 @@
+package com.chungbazi.server.domain.policy.application.cursor;
+
+import com.chungbazi.server.domain.policy.domain.entity.RecentViewedPolicy;
+import com.chungbazi.server.domain.policy.exception.PolicyErrorCode;
+import com.chungbazi.server.domain.policy.exception.PolicyException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Base64;
+
+public final class RecentViewedPolicyCursorParser {
+
+    private static final String CURSOR_SEPARATOR = "\\|";
+    private static final String CURSOR_JOINER = "|";
+    private static final String CURSOR_PREFIX = "RECENT_VIEWED";
+
+    private RecentViewedPolicyCursorParser() {
+    }
+
+    public static String encode(RecentViewedPolicy recentViewedPolicy) {
+        String rawCursor = String.join(
+                CURSOR_JOINER,
+                CURSOR_PREFIX,
+                recentViewedPolicy.getViewedAt().toString(),
+                recentViewedPolicy.getPolicy().getId().toString()
+        );
+
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(rawCursor.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static RecentViewedPolicyCursor decode(String encodedCursor) {
+        if (encodedCursor == null || encodedCursor.isBlank()) {
+            return null;
+        }
+
+        try {
+            String rawCursor = new String(
+                    Base64.getUrlDecoder().decode(encodedCursor),
+                    StandardCharsets.UTF_8
+            );
+            String[] values = rawCursor.split(CURSOR_SEPARATOR, -1);
+
+            if (values.length != 3 || !CURSOR_PREFIX.equals(values[0])) {
+                throw new PolicyException(PolicyErrorCode.INVALID_POLICY_CURSOR);
+            }
+
+            return new RecentViewedPolicyCursor(
+                    LocalDateTime.parse(values[1]),
+                    Long.valueOf(values[2])
+            );
+        } catch (RuntimeException exception) {
+            throw new PolicyException(PolicyErrorCode.INVALID_POLICY_CURSOR);
+        }
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/policy/domain/entity/RecentViewedPolicy.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/domain/entity/RecentViewedPolicy.java
@@ -6,6 +6,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -17,7 +18,15 @@ import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@Table(name = "recent_viewed_policy")
+@Table(
+        name = "recent_viewed_policy",
+        indexes = {
+                @Index(
+                        name = "idx_recent_viewed_policy_user_policy_viewed",
+                        columnList = "user_id,policy_id,viewed_at"
+                )
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RecentViewedPolicy {
 

--- a/src/main/java/com/chungbazi/server/domain/policy/domain/repository/RecentViewedPolicyRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/domain/repository/RecentViewedPolicyRepository.java
@@ -1,9 +1,9 @@
 package com.chungbazi.server.domain.policy.domain.repository;
 
-import com.chungbazi.server.domain.policy.domain.entity.Policy;
 import com.chungbazi.server.domain.policy.domain.entity.RecentViewedPolicy;
 import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
 import com.chungbazi.server.domain.policy.domain.type.SidoCode;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,8 +13,48 @@ import org.springframework.data.repository.query.Param;
 public interface RecentViewedPolicyRepository extends JpaRepository<RecentViewedPolicy, Long> {
 
     @Query("""
-            SELECT recentViewedPolicy.policy
+            SELECT recentViewedPolicy
             FROM RecentViewedPolicy recentViewedPolicy
+            JOIN FETCH recentViewedPolicy.policy
+            WHERE recentViewedPolicy.userId = :userId
+              AND recentViewedPolicy.policy.recruitmentStatus <> :closedStatus
+              AND (
+                    recentViewedPolicy.policy.national = true
+                    OR EXISTS (
+                        SELECT policyRegion.id
+                        FROM PolicyRegion policyRegion
+                        WHERE policyRegion.policy = recentViewedPolicy.policy
+                          AND policyRegion.sidoCode = :sidoCode
+                          AND (
+                                policyRegion.regionCode IS NULL
+                                OR (
+                                    :sigunguCode IS NOT NULL
+                                    AND :sigunguCode <> ''
+                                    AND policyRegion.regionCode.sigunguCode = :sigunguCode
+                                )
+                          )
+                    )
+              )
+              AND recentViewedPolicy.viewedAt = (
+                    SELECT MAX(latestRecentViewedPolicy.viewedAt)
+                    FROM RecentViewedPolicy latestRecentViewedPolicy
+                    WHERE latestRecentViewedPolicy.userId = :userId
+                      AND latestRecentViewedPolicy.policy = recentViewedPolicy.policy
+            )
+            ORDER BY recentViewedPolicy.viewedAt DESC, recentViewedPolicy.policy.id DESC
+            """)
+    List<RecentViewedPolicy> findRecentViewedPolicies(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("sidoCode") SidoCode sidoCode,
+            @Param("sigunguCode") String sigunguCode,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT recentViewedPolicy
+            FROM RecentViewedPolicy recentViewedPolicy
+            JOIN FETCH recentViewedPolicy.policy
             WHERE recentViewedPolicy.userId = :userId
               AND recentViewedPolicy.policy.recruitmentStatus <> :closedStatus
               AND (
@@ -40,13 +80,22 @@ public interface RecentViewedPolicyRepository extends JpaRepository<RecentViewed
                     WHERE latestRecentViewedPolicy.userId = :userId
                       AND latestRecentViewedPolicy.policy = recentViewedPolicy.policy
               )
+              AND (
+                    recentViewedPolicy.viewedAt < :viewedAt
+                    OR (
+                        recentViewedPolicy.viewedAt = :viewedAt
+                        AND recentViewedPolicy.policy.id < :policyId
+                    )
+              )
             ORDER BY recentViewedPolicy.viewedAt DESC, recentViewedPolicy.policy.id DESC
             """)
-    List<Policy> findRecentViewedPolicies(
+    List<RecentViewedPolicy> findRecentViewedPoliciesAfter(
             @Param("userId") Long userId,
             @Param("closedStatus") RecruitmentStatus closedStatus,
             @Param("sidoCode") SidoCode sidoCode,
             @Param("sigunguCode") String sigunguCode,
+            @Param("viewedAt") LocalDateTime viewedAt,
+            @Param("policyId") Long policyId,
             Pageable pageable
     );
 

--- a/src/main/java/com/chungbazi/server/domain/policy/domain/repository/RecentViewedPolicyRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/domain/repository/RecentViewedPolicyRepository.java
@@ -1,7 +1,82 @@
 package com.chungbazi.server.domain.policy.domain.repository;
 
+import com.chungbazi.server.domain.policy.domain.entity.Policy;
 import com.chungbazi.server.domain.policy.domain.entity.RecentViewedPolicy;
+import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
+import com.chungbazi.server.domain.policy.domain.type.SidoCode;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RecentViewedPolicyRepository extends JpaRepository<RecentViewedPolicy, Long> {
+
+    @Query("""
+            SELECT recentViewedPolicy.policy
+            FROM RecentViewedPolicy recentViewedPolicy
+            WHERE recentViewedPolicy.userId = :userId
+              AND recentViewedPolicy.policy.recruitmentStatus <> :closedStatus
+              AND (
+                    recentViewedPolicy.policy.national = true
+                    OR EXISTS (
+                        SELECT policyRegion.id
+                        FROM PolicyRegion policyRegion
+                        WHERE policyRegion.policy = recentViewedPolicy.policy
+                          AND policyRegion.sidoCode = :sidoCode
+                          AND (
+                                policyRegion.regionCode IS NULL
+                                OR (
+                                    :sigunguCode IS NOT NULL
+                                    AND :sigunguCode <> ''
+                                    AND policyRegion.regionCode.sigunguCode = :sigunguCode
+                                )
+                          )
+                    )
+              )
+              AND recentViewedPolicy.viewedAt = (
+                    SELECT MAX(latestRecentViewedPolicy.viewedAt)
+                    FROM RecentViewedPolicy latestRecentViewedPolicy
+                    WHERE latestRecentViewedPolicy.userId = :userId
+                      AND latestRecentViewedPolicy.policy = recentViewedPolicy.policy
+              )
+            ORDER BY recentViewedPolicy.viewedAt DESC, recentViewedPolicy.policy.id DESC
+            """)
+    List<Policy> findRecentViewedPolicies(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("sidoCode") SidoCode sidoCode,
+            @Param("sigunguCode") String sigunguCode,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT COUNT(DISTINCT recentViewedPolicy.policy.id)
+            FROM RecentViewedPolicy recentViewedPolicy
+            WHERE recentViewedPolicy.userId = :userId
+              AND recentViewedPolicy.policy.recruitmentStatus <> :closedStatus
+              AND (
+                    recentViewedPolicy.policy.national = true
+                    OR EXISTS (
+                        SELECT policyRegion.id
+                        FROM PolicyRegion policyRegion
+                        WHERE policyRegion.policy = recentViewedPolicy.policy
+                          AND policyRegion.sidoCode = :sidoCode
+                          AND (
+                                policyRegion.regionCode IS NULL
+                                OR (
+                                    :sigunguCode IS NOT NULL
+                                    AND :sigunguCode <> ''
+                                    AND policyRegion.regionCode.sigunguCode = :sigunguCode
+                                )
+                          )
+                    )
+              )
+            """)
+    long countRecentViewedPolicies(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("sidoCode") SidoCode sidoCode,
+            @Param("sigunguCode") String sigunguCode
+    );
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
- #23

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 홈 화면에서 정렬 별로 정책 최대 5개 조회하는 API 구현했습니다.
최근 본 정책 조회 로직 빼고는 기존 메서드 사용했으니 참고 부탁드립니다.

추후 해당 API에 사용자 맞춤 정책 조회 로직도 추가하시면 될 거 같습니다~!

## 📸 스크린샷
<img width="707" height="449" alt="image" src="https://github.com/user-attachments/assets/345cad25-2135-490a-9084-3edc5e8e4a3d" />

## ✅ 체크리스트
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 테스트 시 사용한 로그를 삭제했습니다.

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

> - **P1:** 꼭 반영해주세요 (Comment)
> - **P2:** 적극적으로 고려해주세요 (Comment)
> - **P3:** 웬만하면 반영해 주세요 (Comment)
> - **P4:** 반영해도 좋고 넘어가도 좋습니다 (Approve)
> - **P5:** 그냥 사소한 의견입니다 (Approve)

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 홈 화면에서 최근 본 정책, 인기 정책, 마감 임박 정책, 최신 정책을 확인할 수 있습니다.
  - 최근 본 정책은 별도 조회로 제공되며, 페이지 크기는 1~5개 범위에서 선택할 수 있습니다(커서 기반).
  - 정책 목록에 사용자의 좋아요 상태가 함께 반영됩니다.
- **문서화**
  - 홈 화면 정책 조회 API 및 최근 본 정책 조회 API의 Swagger 문서가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->