### PR TITLE
[Feat] 카테고리별 맞춤 정책 조회 API 구현

### DIFF
--- a/src/main/java/com/chungbazi/server/domain/policy/api/HomeController.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/HomeController.java
@@ -2,6 +2,7 @@ package com.chungbazi.server.domain.policy.api;
 
 import com.chungbazi.server.domain.policy.api.docs.HomeDocs;
 import com.chungbazi.server.domain.policy.api.dto.response.HomePolicyResponse;
+import com.chungbazi.server.domain.policy.api.dto.response.PersonalizedPolicyResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
 import com.chungbazi.server.domain.policy.application.HomePolicyService;
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
@@ -31,6 +32,17 @@ public class HomeController implements HomeDocs {
     public CommonResponse<HomePolicyResponse> getHomePolicies(@CurrentUser User user) {
         return CommonResponse.onSuccess(
                 homePolicyService.getHomePolicies(user)
+        );
+    }
+
+    @Override
+    @GetMapping("/policies/personalized")
+    public CommonResponse<PersonalizedPolicyResponse> getPersonalizedPoliciesByCategory(
+            @CurrentUser User user,
+            @RequestParam PolicyCategoryType category
+    ) {
+        return CommonResponse.onSuccess(
+                homePolicyService.getPersonalizedPolicies(user, category)
         );
     }
 

--- a/src/main/java/com/chungbazi/server/domain/policy/api/docs/HomeDocs.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/docs/HomeDocs.java
@@ -42,17 +42,23 @@ public interface HomeDocs {
     );
 
     @Operation(
-            summary = "카테고리별 맞춤 정책 조회 API",
-            description = "선택한 정책 카테고리에서 사용자 정보를 기반으로 추천한 정책을 최대 5개 조회합니다."
+            summary = "분야별 맞춤 정책 목록 조회 API",
+            description = """
+                    전국 정책과 현재 사용자의 지역에 해당하는 정책 중에서,
+                    선택한 정책 분야의 맞춤 정책을 추천순으로 최대 5개 조회합니다.
+                    사용자가 관심 분야로 선택하지 않은 정책 분야는 빈 목록을 반환합니다.
+
+                    - `category`: 정책 분야
+                    """
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "카테고리별 맞춤 정책 조회 성공"),
+            @ApiResponse(responseCode = "200", description = "분야별 맞춤 정책 목록 조회 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 카테고리"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
     CommonResponse<PersonalizedPolicyResponse> getPersonalizedPoliciesByCategory(
             @CurrentUser User user,
-            @Parameter(description = "정책 카테고리", example = "JOB_STARTUP", required = true)
+            @Parameter(description = "정책 분야", example = "JOB_STARTUP", required = true)
             @RequestParam PolicyCategoryType category
     );
 

--- a/src/main/java/com/chungbazi/server/domain/policy/api/docs/HomeDocs.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/docs/HomeDocs.java
@@ -2,6 +2,7 @@ package com.chungbazi.server.domain.policy.api.docs;
 
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.HomePolicyResponse;
+import com.chungbazi.server.domain.policy.api.dto.response.PersonalizedPolicyResponse;
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
 import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
 import com.chungbazi.server.domain.user.domain.User;
@@ -38,6 +39,21 @@ public interface HomeDocs {
     })
     CommonResponse<HomePolicyResponse> getHomePolicies(
             @CurrentUser User user
+    );
+
+    @Operation(
+            summary = "카테고리별 맞춤 정책 조회 API",
+            description = "선택한 정책 카테고리에서 사용자 정보를 기반으로 추천한 정책을 최대 5개 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "카테고리별 맞춤 정책 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 카테고리"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    CommonResponse<PersonalizedPolicyResponse> getPersonalizedPoliciesByCategory(
+            @CurrentUser User user,
+            @Parameter(description = "정책 카테고리", example = "JOB_STARTUP", required = true)
+            @RequestParam PolicyCategoryType category
     );
 
     @Operation(

--- a/src/main/java/com/chungbazi/server/domain/policy/api/dto/response/PersonalizedPolicyResponse.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/dto/response/PersonalizedPolicyResponse.java
@@ -1,0 +1,20 @@
+package com.chungbazi.server.domain.policy.api.dto.response;
+
+import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse.PolicySummary;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Schema(description = "카테고리별 맞춤 정책 응답")
+@Builder
+public record PersonalizedPolicyResponse(
+        @Schema(description = "맞춤 정책 목록 (최대 5개)")
+        List<PolicySummary> policies
+) {
+        public static PersonalizedPolicyResponse of(List<PolicySummary> policies) {
+                return PersonalizedPolicyResponse.builder()
+                        .policies(policies)
+                        .build();
+        }
+}

--- a/src/main/java/com/chungbazi/server/domain/policy/application/HomePolicyService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/HomePolicyService.java
@@ -1,6 +1,7 @@
 package com.chungbazi.server.domain.policy.application;
 
 import com.chungbazi.server.domain.policy.api.dto.response.HomePolicyResponse;
+import com.chungbazi.server.domain.policy.api.dto.response.PersonalizedPolicyResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
 import com.chungbazi.server.domain.policy.application.cursor.PolicyCursor;
 import com.chungbazi.server.domain.policy.application.cursor.PolicyCursorParser;
@@ -34,6 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class HomePolicyService {
 
     private static final int HOME_SECTION_SIZE = 5;
+    private static final int PERSONALIZED_CATEGORY_SIZE = 5;
     private static final ZoneId SERVICE_ZONE_ID = ZoneId.of("Asia/Seoul");
 
     private final PolicyRepository policyRepository;
@@ -81,6 +83,21 @@ public class HomePolicyService {
                 upcomingDeadlinePolicies,
                 latestPolicies
         );
+    }
+
+    public PersonalizedPolicyResponse getPersonalizedPolicies(User user, PolicyCategoryType category) {
+        List<Policy> policies = personalizedPolicyService.getPersonalizedPolicyEntities(
+                user,
+                category,
+                PERSONALIZED_CATEGORY_SIZE
+        );
+
+        Set<Long> likedPolicyIds = policyListResponseAssembler.findLikedPolicyIds(
+                user.getId(),
+                policies
+        );
+
+        return PersonalizedPolicyResponse.of(policyListResponseAssembler.summarize(policies, likedPolicyIds));
     }
 
     public PolicyListResponse getRecentViewedPolicies(User user, String cursor, int size) {

--- a/src/main/java/com/chungbazi/server/domain/policy/application/PersonalizedPolicyService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/PersonalizedPolicyService.java
@@ -9,6 +9,7 @@ import com.chungbazi.server.domain.policy.domain.repository.policyRepository.Pol
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
 import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
 import com.chungbazi.server.domain.user.domain.User;
+import com.chungbazi.server.domain.user.domain.UserInterest;
 import com.chungbazi.server.domain.user.infrastructure.UserInterestRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -76,6 +77,49 @@ public class PersonalizedPolicyService {
                     .toList();
         }
         return diversifyByCategory(scoredPolicies, size);
+    }
+
+    public List<Policy> getPersonalizedPolicyEntities(User user, PolicyCategoryType category, int size) {
+        List<UserInterest> interests = userInterestRepository.findAllByUser(user);
+        boolean interestedCategory = interests.stream()
+                .anyMatch(interest -> interest.getCategory() == category);
+
+        // 선택하지 않은 카테고리면 빈 리스트 반환
+        if (!interestedCategory) {
+            return List.of();
+        }
+
+        List<Policy> candidates = policyRepository.findLatestPolicies(
+                category,
+                RecruitmentStatus.CLOSED,
+                user.getSidoCode(),
+                user.getSigunguCode(),
+                PageRequest.of(0, CANDIDATE_SIZE)
+        );
+
+        PolicyRecommendationContext context = PolicyRecommendationContext.of(
+                interests,
+                policyLikeRepository.findRecentPolicyLikesWithPolicy(
+                        user.getId(),
+                        PageRequest.of(0, BEHAVIOR_HISTORY_SIZE)
+                ),
+                recentViewedPolicyRepository.findRecentViewedPolicies(
+                        user.getId(),
+                        RecruitmentStatus.CLOSED,
+                        user.getSidoCode(),
+                        user.getSigunguCode(),
+                        PageRequest.of(0, BEHAVIOR_HISTORY_SIZE)
+                )
+        );
+
+        return candidates.stream()
+                .filter(policy -> scorer.isEligible(user, policy))
+                .sorted(Comparator
+                        .comparingInt((Policy policy) -> scorer.score(user, context, policy))
+                        .reversed()
+                        .thenComparing(Policy::getRegisteredAt, Comparator.reverseOrder()))
+                .limit(size)
+                .toList();
     }
 
     private List<Policy> diversifyByCategory(List<Policy> policies, int size) {


### PR DESCRIPTION
## 🔗 연관된 이슈
- #35

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 카테고리별 맞춤 정책 조회 API 

## 📸 스크린샷
> <img width="712" height="747" alt="image" src="https://github.com/user-attachments/assets/69afdaea-2afc-41ad-8437-70203e5ce8eb" />


## ✅ 체크리스트
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 테스트 시 사용한 로그를 삭제했습니다.

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

> - **P1:** 꼭 반영해주세요 (Comment)
> - **P2:** 적극적으로 고려해주세요 (Comment)
> - **P3:** 웬만하면 반영해 주세요 (Comment)
> - **P4:** 반영해도 좋고 넘어가도 좋습니다 (Approve)
> - **P5:** 그냥 사소한 의견입니다 (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 관심 분야를 기준으로 맞춤형 정책 목록을 조회할 수 있습니다.
  - 사용자의 관심 분야, 좋아요 및 최근 조회 이력을 반영해 관련 정책을 제공합니다.
  - 자격 요건에 맞는 정책을 우선적으로 선별하고, 개인화 점수와 최신 등록일을 기준으로 정렬합니다.
  - 관심을 등록하지 않은 분야는 빈 목록으로 안내합니다.

- **문서**
  - 정책 분야 선택, 인증 필요 여부 및 잘못된 분야 입력에 대한 API 안내를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->