### PR TITLE
[Feat] 내 정책 기능 구현

### DIFF
--- a/src/main/java/com/chungbazi/server/domain/policy/api/HomeController.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/HomeController.java
@@ -6,7 +6,7 @@ import com.chungbazi.server.domain.policy.api.dto.response.PersonalizedPolicyRes
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
 import com.chungbazi.server.domain.policy.application.HomePolicyService;
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
-import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
+import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.global.common.CommonResponse;
 import com.chungbazi.server.global.resolver.CurrentUser;
@@ -63,7 +63,7 @@ public class HomeController implements HomeDocs {
     public CommonResponse<PolicyListResponse> getPoliciesByCategory(
             @CurrentUser User user,
             @RequestParam PolicyCategoryType category,
-            @RequestParam(defaultValue = "LATEST") PolicySortType sort,
+            @RequestParam(defaultValue = "LATEST") PolicyListSortType sort,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
     ) {

--- a/src/main/java/com/chungbazi/server/domain/policy/api/HomeController.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/HomeController.java
@@ -5,7 +5,7 @@ import com.chungbazi.server.domain.policy.api.dto.response.HomePolicyResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
 import com.chungbazi.server.domain.policy.application.HomePolicyService;
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
-import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
+import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.global.common.CommonResponse;
 import com.chungbazi.server.global.resolver.CurrentUser;
@@ -51,7 +51,7 @@ public class HomeController implements HomeDocs {
     public CommonResponse<PolicyListResponse> getPoliciesByCategory(
             @CurrentUser User user,
             @RequestParam PolicyCategoryType category,
-            @RequestParam(defaultValue = "LATEST") PolicySortType sort,
+            @RequestParam(defaultValue = "LATEST") PolicyListSortType sort,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
     ) {

--- a/src/main/java/com/chungbazi/server/domain/policy/api/MyPolicyController.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/MyPolicyController.java
@@ -2,15 +2,24 @@ package com.chungbazi.server.domain.policy.api;
 
 import com.chungbazi.server.domain.policy.api.docs.MyPolicyDocs;
 import com.chungbazi.server.domain.policy.api.dto.response.MyPolicyDeadlineResponse;
+import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
 import com.chungbazi.server.domain.policy.application.MyPolicyService;
+import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.global.common.CommonResponse;
 import com.chungbazi.server.global.resolver.CurrentUser;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/my-policy")
@@ -23,5 +32,18 @@ public class MyPolicyController implements MyPolicyDocs {
     public CommonResponse<MyPolicyDeadlineResponse> getMyPolicyDeadline(@CurrentUser User user) {
 
         return CommonResponse.onSuccess(myPolicyService.getMyPolicyDeadline(user));
+    }
+
+    @Override
+    @GetMapping("/policies/deadline/date")
+    public CommonResponse<PolicyListResponse> getDeadlinePoliciesByDate(
+            @CurrentUser User user,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate,
+            @RequestParam(defaultValue = "LATEST") PolicySortType sort,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
+    ) {
+
+        return CommonResponse.onSuccess(myPolicyService.getDeadlinePoliciesByDate(user, targetDate, sort, cursor, size));
     }
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/api/MyPolicyController.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/MyPolicyController.java
@@ -1,0 +1,27 @@
+package com.chungbazi.server.domain.policy.api;
+
+import com.chungbazi.server.domain.policy.api.docs.MyPolicyDocs;
+import com.chungbazi.server.domain.policy.api.dto.response.MyPolicyDeadlineResponse;
+import com.chungbazi.server.domain.policy.application.MyPolicyService;
+import com.chungbazi.server.domain.user.domain.User;
+import com.chungbazi.server.global.common.CommonResponse;
+import com.chungbazi.server.global.resolver.CurrentUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/my-policy")
+public class MyPolicyController implements MyPolicyDocs {
+
+    private final MyPolicyService myPolicyService;
+
+    @Override
+    @GetMapping("/policies/deadline")
+    public CommonResponse<MyPolicyDeadlineResponse> getMyPolicyDeadline(@CurrentUser User user) {
+
+        return CommonResponse.onSuccess(myPolicyService.getMyPolicyDeadline(user));
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/policy/api/MyPolicyController.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/MyPolicyController.java
@@ -9,8 +9,6 @@ import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.global.common.CommonResponse;
 import com.chungbazi.server.global.resolver.CurrentUser;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -29,44 +27,44 @@ public class MyPolicyController implements MyPolicyDocs {
     private final MyPolicyService myPolicyService;
 
     @Override
-    @GetMapping("/policies/deadline")
+    @GetMapping("/deadline")
     public CommonResponse<MyPolicyDeadlineResponse> getMyPolicyDeadline(@CurrentUser User user) {
 
         return CommonResponse.onSuccess(myPolicyService.getMyPolicyDeadline(user));
     }
 
     @Override
-    @GetMapping("/policies/deadline/date")
+    @GetMapping("/deadline/date")
     public CommonResponse<PolicyListResponse> getDeadlinePoliciesByDate(
             @CurrentUser User user,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate,
             @RequestParam(defaultValue = "LATEST") PolicyListSortType sort,
             @RequestParam(required = false) String cursor,
-            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
+            @RequestParam(defaultValue = "20") int size
     ) {
 
         return CommonResponse.onSuccess(myPolicyService.getDeadlinePoliciesByDate(user, targetDate, sort, cursor, size));
     }
 
     @Override
-    @GetMapping("/policies/open-ended")
+    @GetMapping("/open-ended")
     public CommonResponse<PolicyListResponse> getOpenEndedLikedPolicies(
             @CurrentUser User user,
             @RequestParam(required = false) String cursor,
-            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
+            @RequestParam(defaultValue = "20") int size
     ) {
 
         return CommonResponse.onSuccess(myPolicyService.getOpenEndedLikedPolicies(user, cursor, size));
     }
 
     @Override
-    @GetMapping("/policies")
+    @GetMapping
     public CommonResponse<PolicyListResponse> getMyPoliciesByCategory(
             @CurrentUser User user,
             @RequestParam(required = false) PolicyCategoryType category,
             @RequestParam(defaultValue = "LATEST") PolicyListSortType sort,
             @RequestParam(required = false) String cursor,
-            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
+            @RequestParam(defaultValue = "20") int size
     ) {
 
         return CommonResponse.onSuccess(myPolicyService.getMyPoliciesByCategory(user, category, sort, cursor, size));

--- a/src/main/java/com/chungbazi/server/domain/policy/api/MyPolicyController.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/MyPolicyController.java
@@ -4,6 +4,7 @@ import com.chungbazi.server.domain.policy.api.docs.MyPolicyDocs;
 import com.chungbazi.server.domain.policy.api.dto.response.MyPolicyDeadlineResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
 import com.chungbazi.server.domain.policy.application.MyPolicyService;
+import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
 import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.global.common.CommonResponse;
@@ -56,5 +57,18 @@ public class MyPolicyController implements MyPolicyDocs {
     ) {
 
         return CommonResponse.onSuccess(myPolicyService.getOpenEndedLikedPolicies(user, cursor, size));
+    }
+
+    @Override
+    @GetMapping("/policies")
+    public CommonResponse<PolicyListResponse> getMyPoliciesByCategory(
+            @CurrentUser User user,
+            @RequestParam(required = false) PolicyCategoryType category,
+            @RequestParam(defaultValue = "LATEST") PolicyListSortType sort,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
+    ) {
+
+        return CommonResponse.onSuccess(myPolicyService.getMyPoliciesByCategory(user, category, sort, cursor, size));
     }
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/api/MyPolicyController.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/MyPolicyController.java
@@ -4,7 +4,7 @@ import com.chungbazi.server.domain.policy.api.docs.MyPolicyDocs;
 import com.chungbazi.server.domain.policy.api.dto.response.MyPolicyDeadlineResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
 import com.chungbazi.server.domain.policy.application.MyPolicyService;
-import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
+import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.global.common.CommonResponse;
 import com.chungbazi.server.global.resolver.CurrentUser;
@@ -39,7 +39,7 @@ public class MyPolicyController implements MyPolicyDocs {
     public CommonResponse<PolicyListResponse> getDeadlinePoliciesByDate(
             @CurrentUser User user,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate,
-            @RequestParam(defaultValue = "LATEST") PolicySortType sort,
+            @RequestParam(defaultValue = "LATEST") PolicyListSortType sort,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
     ) {

--- a/src/main/java/com/chungbazi/server/domain/policy/api/MyPolicyController.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/MyPolicyController.java
@@ -46,4 +46,15 @@ public class MyPolicyController implements MyPolicyDocs {
 
         return CommonResponse.onSuccess(myPolicyService.getDeadlinePoliciesByDate(user, targetDate, sort, cursor, size));
     }
+
+    @Override
+    @GetMapping("/policies/open-ended")
+    public CommonResponse<PolicyListResponse> getOpenEndedLikedPolicies(
+            @CurrentUser User user,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
+    ) {
+
+        return CommonResponse.onSuccess(myPolicyService.getOpenEndedLikedPolicies(user, cursor, size));
+    }
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/api/PolicySearchController.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/PolicySearchController.java
@@ -5,7 +5,7 @@ import com.chungbazi.server.domain.policy.api.dto.response.SearchSuggestionRespo
 import com.chungbazi.server.domain.policy.api.docs.PolicySearchDocs;
 import com.chungbazi.server.domain.policy.application.PolicySearchService;
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
-import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
+import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.global.common.CommonResponse;
 import com.chungbazi.server.global.resolver.CurrentUser;
@@ -27,7 +27,7 @@ public class PolicySearchController implements PolicySearchDocs {
             @CurrentUser User user,
             @RequestParam String keyword,
             @RequestParam(required = false) PolicyCategoryType category,
-            @RequestParam(defaultValue = "LATEST") PolicySortType sort,
+            @RequestParam(defaultValue = "LATEST") PolicyListSortType sort,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
     ) {

--- a/src/main/java/com/chungbazi/server/domain/policy/api/docs/HomeDocs.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/docs/HomeDocs.java
@@ -3,7 +3,7 @@ package com.chungbazi.server.domain.policy.api.docs;
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.HomePolicyResponse;
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
-import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
+import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.global.common.CommonResponse;
 import com.chungbazi.server.global.resolver.CurrentUser;
@@ -84,7 +84,7 @@ public interface HomeDocs {
             @Parameter(description = "정책 분야", example = "JOB_STARTUP", required = true)
             @RequestParam PolicyCategoryType category,
             @Parameter(description = "정렬 기준", example = "LATEST")
-            @RequestParam(defaultValue = "LATEST") PolicySortType sort,
+            @RequestParam(defaultValue = "LATEST") PolicyListSortType sort,
             @Parameter(description = "이전 응답에서 받은 다음 페이지 커서")
             @RequestParam(required = false) String cursor,
             @Parameter(description = "조회 개수", example = "20")

--- a/src/main/java/com/chungbazi/server/domain/policy/api/docs/HomeDocs.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/docs/HomeDocs.java
@@ -4,7 +4,7 @@ import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.HomePolicyResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.PersonalizedPolicyResponse;
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
-import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
+import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.global.common.CommonResponse;
 import com.chungbazi.server.global.resolver.CurrentUser;
@@ -106,7 +106,7 @@ public interface HomeDocs {
             @Parameter(description = "정책 분야", example = "JOB_STARTUP", required = true)
             @RequestParam PolicyCategoryType category,
             @Parameter(description = "정렬 기준", example = "LATEST")
-            @RequestParam(defaultValue = "LATEST") PolicySortType sort,
+            @RequestParam(defaultValue = "LATEST") PolicyListSortType sort,
             @Parameter(description = "이전 응답에서 받은 다음 페이지 커서")
             @RequestParam(required = false) String cursor,
             @Parameter(description = "조회 개수", example = "20")

--- a/src/main/java/com/chungbazi/server/domain/policy/api/docs/MyPolicyDocs.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/docs/MyPolicyDocs.java
@@ -2,7 +2,7 @@ package com.chungbazi.server.domain.policy.api.docs;
 
 import com.chungbazi.server.domain.policy.api.dto.response.MyPolicyDeadlineResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
-import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
+import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.global.common.CommonResponse;
 import com.chungbazi.server.global.resolver.CurrentUser;
@@ -53,7 +53,7 @@ public interface MyPolicyDocs {
             @Parameter(description = "사용자가 확인하고 싶은 날짜", example = "2026-08-06", required = true)
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate,
             @Parameter(description = "정렬 기준", example = "LATEST")
-            @RequestParam(defaultValue = "LATEST") PolicySortType sort,
+            @RequestParam(defaultValue = "LATEST") PolicyListSortType sort,
             @Parameter(description = "이전 응답에서 받은 다음 페이지 커서")
             @RequestParam(required = false) String cursor,
             @Parameter(description = "조회 개수", example = "20")

--- a/src/main/java/com/chungbazi/server/domain/policy/api/docs/MyPolicyDocs.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/docs/MyPolicyDocs.java
@@ -59,4 +59,28 @@ public interface MyPolicyDocs {
             @Parameter(description = "조회 개수", example = "20")
             @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
     );
+
+    @Operation(
+            summary = "찜한 상시 정책 리스트 조회 API",
+            description = """
+                    찜한 상시 정책 리스트를 조회하는 API입니다. \n
+                    사용자가 최근 찜한 순입니다.
+
+                    ### Query Parameter
+                    - `cursor`: 최초 요청에서는 생략하고, 다음 요청부터 응답의 `nextCursor`를 전달합니다.
+                    - `size`: 한 번에 조회할 정책 수(기본 20, 최대 50)
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "찜한 상시 정책 리스트 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 커서"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    CommonResponse<PolicyListResponse> getOpenEndedLikedPolicies(
+            @CurrentUser User user,
+            @Parameter(description = "이전 응답에서 받은 다음 페이지 커서")
+            @RequestParam(required = false) String cursor,
+            @Parameter(description = "조회 개수", example = "20")
+            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
+    );
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/api/docs/MyPolicyDocs.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/docs/MyPolicyDocs.java
@@ -1,13 +1,21 @@
 package com.chungbazi.server.domain.policy.api.docs;
 
 import com.chungbazi.server.domain.policy.api.dto.response.MyPolicyDeadlineResponse;
+import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
+import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.global.common.CommonResponse;
 import com.chungbazi.server.global.resolver.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "[My Policy]", description = "내 정책 관련 API")
 public interface MyPolicyDocs {
@@ -22,4 +30,33 @@ public interface MyPolicyDocs {
             @ApiResponse(responseCode = "200", description = "마감이 다가오는 찜한 정책 조회 성공"),
     })
     CommonResponse<MyPolicyDeadlineResponse> getMyPolicyDeadline(@CurrentUser User user);
+
+    @Operation(
+            summary = "현재 날짜에 마감되는 정책 조회 API",
+            description = """
+                    사용자가 확인하고 싶은 날짜의 찜한 정책을 조회하는 API입니다. \n
+
+                    ### Query Parameter
+                    - `targetDate`: 사용자가 확인하고 싶은 날짜로, YYYY-MM-DD 형식입니다.
+                    - `sort`: `LATEST`(최신순), `DEADLINE`(마감순)
+                    - `cursor`: 최초 요청에서는 생략하고, 다음 요청부터 응답의 `nextCursor`를 전달합니다.
+                    - `size`: 한 번에 조회할 정책 수(기본 20, 최대 50)
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "현재 날짜에 마감되는 찜한 정책 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 날짜, 정렬 또는 커서"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    CommonResponse<PolicyListResponse> getDeadlinePoliciesByDate(
+            @CurrentUser User user,
+            @Parameter(description = "사용자가 확인하고 싶은 날짜", example = "2026-08-06", required = true)
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate,
+            @Parameter(description = "정렬 기준", example = "LATEST")
+            @RequestParam(defaultValue = "LATEST") PolicySortType sort,
+            @Parameter(description = "이전 응답에서 받은 다음 페이지 커서")
+            @RequestParam(required = false) String cursor,
+            @Parameter(description = "조회 개수", example = "20")
+            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
+    );
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/api/docs/MyPolicyDocs.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/docs/MyPolicyDocs.java
@@ -1,0 +1,25 @@
+package com.chungbazi.server.domain.policy.api.docs;
+
+import com.chungbazi.server.domain.policy.api.dto.response.MyPolicyDeadlineResponse;
+import com.chungbazi.server.domain.user.domain.User;
+import com.chungbazi.server.global.common.CommonResponse;
+import com.chungbazi.server.global.resolver.CurrentUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "[My Policy]", description = "내 정책 관련 API")
+public interface MyPolicyDocs {
+
+    @Operation(
+            summary = "마감이 다가오는 찜한 정책 조회 API",
+            description = """
+            내 정책 조회 시, 상단에 마감이 다가오는 찜한 정책을 조회하는 API 입니다. \n
+            마감 잔여일이 적은 순이며, 최대 5개 정책을 반환합니다.
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "마감이 다가오는 찜한 정책 조회 성공"),
+    })
+    CommonResponse<MyPolicyDeadlineResponse> getMyPolicyDeadline(@CurrentUser User user);
+}

--- a/src/main/java/com/chungbazi/server/domain/policy/api/docs/MyPolicyDocs.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/docs/MyPolicyDocs.java
@@ -2,6 +2,7 @@ package com.chungbazi.server.domain.policy.api.docs;
 
 import com.chungbazi.server.domain.policy.api.dto.response.MyPolicyDeadlineResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
+import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
 import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.global.common.CommonResponse;
@@ -78,6 +79,29 @@ public interface MyPolicyDocs {
     })
     CommonResponse<PolicyListResponse> getOpenEndedLikedPolicies(
             @CurrentUser User user,
+            @Parameter(description = "이전 응답에서 받은 다음 페이지 커서")
+            @RequestParam(required = false) String cursor,
+            @Parameter(description = "조회 개수", example = "20")
+            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
+    );
+
+    @Operation(
+            summary = "내 정책 전체보기 API",
+            description = """
+                    사용자가 찜한 정책을 카테고리별로 조회할 수 있는 API입니다. \n
+
+                    ### Query Parameter
+                    - `category`: 정책 분야
+                    - `sort`: `LATEST`(최신순), `DEADLINE`(마감순)
+                    - `cursor`: 최초 요청에서는 생략하고, 다음 요청부터 응답의 `nextCursor`를 전달합니다.
+                    - `size`: 한 번에 조회할 정책 수(기본 20, 최대 50)
+                    """)
+    CommonResponse<PolicyListResponse> getMyPoliciesByCategory(
+            @CurrentUser User user,
+            @Parameter(description = "정책 분야", example = "JOB_STARTUP")
+            @RequestParam(required = false) PolicyCategoryType category,
+            @Parameter(description = "정렬 기준", example = "LATEST")
+            @RequestParam(defaultValue = "LATEST") PolicyListSortType sort,
             @Parameter(description = "이전 응답에서 받은 다음 페이지 커서")
             @RequestParam(required = false) String cursor,
             @Parameter(description = "조회 개수", example = "20")

--- a/src/main/java/com/chungbazi/server/domain/policy/api/docs/PolicySearchDocs.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/docs/PolicySearchDocs.java
@@ -3,7 +3,7 @@ package com.chungbazi.server.domain.policy.api.docs;
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.SearchSuggestionResponse;
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
-import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
+import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.global.common.CommonResponse;
 import com.chungbazi.server.global.resolver.CurrentUser;
@@ -49,7 +49,7 @@ public interface PolicySearchDocs {
             @Parameter(description = "정책 분야. 생략하면 전체 분야 검색", example = "HOUSING")
             @RequestParam(required = false) PolicyCategoryType category,
             @Parameter(description = "정렬 기준", example = "LATEST")
-            @RequestParam(defaultValue = "LATEST") PolicySortType sort,
+            @RequestParam(defaultValue = "LATEST") PolicyListSortType sort,
             @Parameter(description = "이전 응답에서 받은 다음 페이지 커서")
             @RequestParam(required = false) String cursor,
             @Parameter(description = "조회 개수", example = "20")

--- a/src/main/java/com/chungbazi/server/domain/policy/api/dto/response/MyPolicyDeadlineResponse.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/api/dto/response/MyPolicyDeadlineResponse.java
@@ -1,0 +1,13 @@
+package com.chungbazi.server.domain.policy.api.dto.response;
+
+import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse.PolicySummary;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "마감이 다가오는 찜한 정책 리스트 조회 응답")
+public record MyPolicyDeadlineResponse(
+
+        @Schema(description = "정책 목록")
+        List<PolicySummary> policies
+) {
+}

--- a/src/main/java/com/chungbazi/server/domain/policy/application/HomePolicyService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/HomePolicyService.java
@@ -14,6 +14,7 @@ import com.chungbazi.server.domain.policy.domain.entity.RecentViewedPolicy;
 import com.chungbazi.server.domain.policy.domain.repository.RecentViewedPolicyRepository;
 import com.chungbazi.server.domain.policy.domain.repository.policyRepository.PolicyRepository;
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
+import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
 import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
 import com.chungbazi.server.domain.policy.exception.PolicyErrorCode;
@@ -163,6 +164,16 @@ public class HomePolicyService {
     public PolicyListResponse getPolicies(
             User user,
             PolicyCategoryType category,
+            PolicyListSortType sort,
+            String cursor,
+            int size
+    ) {
+        return getPoliciesBySort(user, category, sort.getPolicySortType(), cursor, size);
+    }
+
+    private PolicyListResponse getPoliciesBySort(
+            User user,
+            PolicyCategoryType category,
             PolicySortType sort,
             String cursor,
             int size
@@ -198,7 +209,7 @@ public class HomePolicyService {
             String cursor,
             int size
     ) {
-        return getPolicies(
+        return getPoliciesBySort(
                 user,
                 category,
                 PolicySortType.LATEST,

--- a/src/main/java/com/chungbazi/server/domain/policy/application/HomePolicyService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/HomePolicyService.java
@@ -13,6 +13,7 @@ import com.chungbazi.server.domain.policy.domain.entity.RecentViewedPolicy;
 import com.chungbazi.server.domain.policy.domain.repository.RecentViewedPolicyRepository;
 import com.chungbazi.server.domain.policy.domain.repository.policyRepository.PolicyRepository;
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
+import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
 import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
 import com.chungbazi.server.domain.policy.exception.PolicyErrorCode;
@@ -146,6 +147,16 @@ public class HomePolicyService {
     public PolicyListResponse getPolicies(
             User user,
             PolicyCategoryType category,
+            PolicyListSortType sort,
+            String cursor,
+            int size
+    ) {
+        return getPoliciesBySort(user, category, sort.getPolicySortType(), cursor, size);
+    }
+
+    private PolicyListResponse getPoliciesBySort(
+            User user,
+            PolicyCategoryType category,
             PolicySortType sort,
             String cursor,
             int size
@@ -181,7 +192,7 @@ public class HomePolicyService {
             String cursor,
             int size
     ) {
-        return getPolicies(
+        return getPoliciesBySort(
                 user,
                 category,
                 PolicySortType.LATEST,

--- a/src/main/java/com/chungbazi/server/domain/policy/application/MyPolicyService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/MyPolicyService.java
@@ -1,14 +1,22 @@
 package com.chungbazi.server.domain.policy.application;
 
 import com.chungbazi.server.domain.policy.api.dto.response.MyPolicyDeadlineResponse;
+import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse;
 import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse.PolicySummary;
+import com.chungbazi.server.domain.policy.application.cursor.PolicyCursor;
+import com.chungbazi.server.domain.policy.application.cursor.PolicyCursorParser;
+import com.chungbazi.server.domain.policy.application.mapper.PolicyListResponseAssembler;
 import com.chungbazi.server.domain.policy.application.mapper.PolicyDisplayMapper;
 import com.chungbazi.server.domain.policy.domain.entity.Policy;
 import com.chungbazi.server.domain.policy.domain.repository.PolicyLikeRepository;
+import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
 import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
+import com.chungbazi.server.domain.policy.exception.PolicyErrorCode;
+import com.chungbazi.server.domain.policy.exception.PolicyException;
 import com.chungbazi.server.domain.user.domain.User;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,6 +35,7 @@ public class MyPolicyService {
 
     private final PolicyLikeRepository policyLikeRepository;
     private final PolicyDisplayMapper policyDisplayMapper;
+    private final PolicyListResponseAssembler policyListResponseAssembler;
 
     public MyPolicyDeadlineResponse getMyPolicyDeadline(User user) {
         LocalDate today = LocalDate.now(SERVICE_ZONE_ID);
@@ -46,5 +55,91 @@ public class MyPolicyService {
 
         List<PolicySummary> policySummaries = policyDisplayMapper.toSummaries(policies, likedPolicyIds);
         return new MyPolicyDeadlineResponse(policySummaries);
+    }
+
+    public PolicyListResponse getDeadlinePoliciesByDate(User user, LocalDate targetDate, PolicySortType sort, String cursor, int size) {
+        validateDeadlineDateSort(sort);
+
+        PolicyCursor decodedCursor = PolicyCursorParser.decode(cursor, sort);
+        PageRequest pageRequest = PageRequest.of(0, size + 1);
+
+        List<Policy> fetchedPolicies = fetchDeadlinePoliciesByDate(
+                user.getId(),
+                targetDate,
+                sort,
+                decodedCursor,
+                pageRequest
+        );
+
+        boolean hasNext = fetchedPolicies.size() > size;
+        List<Policy> policies = hasNext
+                ? new ArrayList<>(fetchedPolicies.subList(0, size))
+                : fetchedPolicies;
+
+        Set<Long> likedPolicyIds = policies.stream()
+                .map(Policy::getId)
+                .collect(Collectors.toSet());
+
+        String nextCursor = hasNext
+                ? PolicyCursorParser.encode(sort, policies.getLast())
+                : null;
+
+        Long totalCount = policyLikeRepository.countDeadlineLikedPoliciesByDate(
+                user.getId(),
+                RecruitmentStatus.CLOSED,
+                targetDate
+        );
+
+        return policyListResponseAssembler.assemble(
+                totalCount,
+                policyListResponseAssembler.summarize(policies, likedPolicyIds),
+                nextCursor,
+                hasNext
+        );
+    }
+
+    private List<Policy> fetchDeadlinePoliciesByDate(Long userId, LocalDate targetDate, PolicySortType sort, PolicyCursor cursor, PageRequest pageRequest) {
+        if (sort == PolicySortType.DEADLINE) {
+            if (cursor == null) {
+                return policyLikeRepository.findDeadlineLikedPoliciesByDateOrderByDeadlineFirst(
+                        userId,
+                        RecruitmentStatus.CLOSED,
+                        targetDate,
+                        pageRequest
+                );
+            }
+
+            return policyLikeRepository.findDeadlineLikedPoliciesByDateOrderByDeadlineAfter(
+                    userId,
+                    RecruitmentStatus.CLOSED,
+                    targetDate,
+                    cursor.policyId(),
+                    pageRequest
+            );
+        }
+
+        if (cursor == null) {
+            return policyLikeRepository.findDeadlineLikedPoliciesByDateOrderByLatestFirst(
+                    userId,
+                    RecruitmentStatus.CLOSED,
+                    targetDate,
+                    pageRequest
+            );
+        }
+
+        return policyLikeRepository.findDeadlineLikedPoliciesByDateOrderByLatestAfter(
+                userId,
+                RecruitmentStatus.CLOSED,
+                targetDate,
+                cursor.registeredAt(),
+                cursor.policyId(),
+                pageRequest
+        );
+    }
+
+    private void validateDeadlineDateSort(PolicySortType sort) {
+        if (sort == PolicySortType.POPULAR) {
+            throw new PolicyException(PolicyErrorCode.INVALID_POLICY_SORT);
+        }
     }
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/application/MyPolicyService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/MyPolicyService.java
@@ -10,6 +10,7 @@ import com.chungbazi.server.domain.policy.application.mapper.PolicyDisplayMapper
 import com.chungbazi.server.domain.policy.domain.entity.Policy;
 import com.chungbazi.server.domain.policy.domain.entity.PolicyLike;
 import com.chungbazi.server.domain.policy.domain.repository.PolicyLikeRepository;
+import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
 import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
 import com.chungbazi.server.domain.policy.domain.type.RecruitmentType;
@@ -22,6 +23,7 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -74,30 +76,17 @@ public class MyPolicyService {
                 pageRequest
         );
 
-        boolean hasNext = fetchedPolicies.size() > size;
-        List<Policy> policies = hasNext
-                ? new ArrayList<>(fetchedPolicies.subList(0, size))
-                : fetchedPolicies;
-
-        Set<Long> likedPolicyIds = policies.stream()
-                .map(Policy::getId)
-                .collect(Collectors.toSet());
-
-        String nextCursor = hasNext
-                ? PolicyCursorParser.encode(policySort, policies.getLast())
-                : null;
-
         Long totalCount = policyLikeRepository.countDeadlineLikedPoliciesByDate(
                 user.getId(),
                 RecruitmentStatus.CLOSED,
                 targetDate
         );
 
-        return policyListResponseAssembler.assemble(
+        return assembleLikedPolicyListResponse(
+                fetchedPolicies,
                 totalCount,
-                policyListResponseAssembler.summarize(policies, likedPolicyIds),
-                nextCursor,
-                hasNext
+                size,
+                policy -> encodeLikedPolicyCursor(policySort, policy)
         );
     }
 
@@ -159,10 +148,6 @@ public class MyPolicyService {
                 .map(PolicyLike::getPolicy)
                 .toList();
 
-        Set<Long> likedPolicyIds = policies.stream()
-                .map(Policy::getId)
-                .collect(Collectors.toSet());
-
         String nextCursor = hasNext
                 ? policyLikes.getLast().getId().toString()
                 : null;
@@ -173,12 +158,7 @@ public class MyPolicyService {
                 RecruitmentType.ALWAYS
         );
 
-        return policyListResponseAssembler.assemble(
-                totalCount,
-                policyListResponseAssembler.summarize(policies, likedPolicyIds),
-                nextCursor,
-                hasNext
-        );
+        return assembleLikedPolicyListResponse(policies, totalCount, nextCursor, hasNext);
     }
 
     private List<PolicyLike> fetchOpenEndedLikedPolicies(
@@ -214,5 +194,162 @@ public class MyPolicyService {
         } catch (NumberFormatException exception) {
             throw new PolicyException(PolicyErrorCode.INVALID_POLICY_CURSOR);
         }
+    }
+
+    public PolicyListResponse getMyPoliciesByCategory(
+            User user,
+            PolicyCategoryType category,
+            PolicyListSortType sort,
+            String cursor,
+            int size
+    ) {
+        PolicySortType policySort = sort.getPolicySortType();
+        PolicyCursor decodedCursor = PolicyCursorParser.decode(cursor, policySort);
+
+        List<Policy> fetchedPolicies = fetchMyPoliciesByCategory(
+                user.getId(),
+                category,
+                policySort,
+                decodedCursor,
+                PageRequest.of(0, size + 1)
+        );
+        Long totalCount = policyLikeRepository.countMyLikedPolicies(
+                user.getId(),
+                RecruitmentStatus.CLOSED,
+                category
+        );
+
+        return assembleLikedPolicyListResponse(
+                fetchedPolicies,
+                totalCount,
+                size,
+                policy -> encodeLikedPolicyCursor(policySort, policy)
+        );
+    }
+
+    private PolicyListResponse assembleLikedPolicyListResponse(
+            List<Policy> fetchedPolicies,
+            Long totalCount,
+            int size,
+            Function<Policy, String> nextCursorEncoder
+    ) {
+        boolean hasNext = fetchedPolicies.size() > size;
+        List<Policy> policies = hasNext
+                ? new ArrayList<>(fetchedPolicies.subList(0, size))
+                : fetchedPolicies;
+
+        String nextCursor = hasNext
+                ? nextCursorEncoder.apply(policies.getLast())
+                : null;
+
+        return assembleLikedPolicyListResponse(policies, totalCount, nextCursor, hasNext);
+    }
+
+    private PolicyListResponse assembleLikedPolicyListResponse(
+            List<Policy> policies,
+            Long totalCount,
+            String nextCursor,
+            boolean hasNext
+    ) {
+        Set<Long> likedPolicyIds = policies.stream()
+                .map(Policy::getId)
+                .collect(Collectors.toSet());
+
+        return policyListResponseAssembler.assemble(
+                totalCount,
+                policyListResponseAssembler.summarize(policies, likedPolicyIds),
+                nextCursor,
+                hasNext
+        );
+    }
+
+    private List<Policy> fetchMyPoliciesByCategory(
+            Long userId,
+            PolicyCategoryType category,
+            PolicySortType sort,
+            PolicyCursor cursor,
+            PageRequest pageRequest
+    ) {
+        if (sort == PolicySortType.LATEST) {
+            return fetchMyPoliciesByLatest(userId, category, cursor, pageRequest);
+        }
+
+        return fetchMyPoliciesByDeadline(userId, category, cursor, pageRequest);
+    }
+
+    private List<Policy> fetchMyPoliciesByLatest(
+            Long userId,
+            PolicyCategoryType category,
+            PolicyCursor cursor,
+            PageRequest pageRequest
+    ) {
+        if (cursor == null) {
+            return policyLikeRepository.findMyLikedPoliciesOrderByLatestFirst(
+                    userId,
+                    RecruitmentStatus.CLOSED,
+                    category,
+                    pageRequest
+            );
+        }
+
+        return policyLikeRepository.findMyLikedPoliciesOrderByLatestAfter(
+                userId,
+                RecruitmentStatus.CLOSED,
+                category,
+                cursor.registeredAt(),
+                cursor.policyId(),
+                pageRequest
+        );
+    }
+
+    private List<Policy> fetchMyPoliciesByDeadline(
+            Long userId,
+            PolicyCategoryType category,
+            PolicyCursor cursor,
+            PageRequest pageRequest
+    ) {
+        if (cursor == null) {
+            return policyLikeRepository.findMyLikedPoliciesOrderByDeadlineFirst(
+                    userId,
+                    RecruitmentStatus.CLOSED,
+                    category,
+                    RecruitmentType.ALWAYS,
+                    pageRequest
+            );
+        }
+
+        if (cursor.applyEndDate() == null) {
+            return policyLikeRepository.findMyLikedPoliciesOrderByDeadlineAfterOpenEndedCursor(
+                    userId,
+                    RecruitmentStatus.CLOSED,
+                    category,
+                    RecruitmentType.ALWAYS,
+                    cursor.policyId(),
+                    pageRequest
+            );
+        }
+
+        return policyLikeRepository.findMyLikedPoliciesOrderByDeadlineAfterDatedCursor(
+                userId,
+                RecruitmentStatus.CLOSED,
+                category,
+                RecruitmentType.ALWAYS,
+                cursor.applyEndDate(),
+                cursor.policyId(),
+                pageRequest
+        );
+    }
+
+    private String encodeLikedPolicyCursor(PolicySortType sort, Policy policy) {
+        if (sort == PolicySortType.DEADLINE && isOpenEndedPolicy(policy)) {
+            return PolicyCursorParser.encodeOpenEndedDeadline(policy.getId());
+        }
+
+        return PolicyCursorParser.encode(sort, policy);
+    }
+
+    private boolean isOpenEndedPolicy(Policy policy) {
+        return policy.getRecruitmentType() == RecruitmentType.ALWAYS
+                || policy.getApplyEndDate() == null;
     }
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/application/MyPolicyService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/MyPolicyService.java
@@ -1,0 +1,50 @@
+package com.chungbazi.server.domain.policy.application;
+
+import com.chungbazi.server.domain.policy.api.dto.response.MyPolicyDeadlineResponse;
+import com.chungbazi.server.domain.policy.api.dto.response.PolicyListResponse.PolicySummary;
+import com.chungbazi.server.domain.policy.application.mapper.PolicyDisplayMapper;
+import com.chungbazi.server.domain.policy.domain.entity.Policy;
+import com.chungbazi.server.domain.policy.domain.repository.PolicyLikeRepository;
+import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
+import com.chungbazi.server.domain.user.domain.User;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPolicyService {
+
+    private static final ZoneId SERVICE_ZONE_ID = ZoneId.of("Asia/Seoul");
+    private static final int MAX_DEADLINE_SIZE = 5;
+
+    private final PolicyLikeRepository policyLikeRepository;
+    private final PolicyDisplayMapper policyDisplayMapper;
+
+    public MyPolicyDeadlineResponse getMyPolicyDeadline(User user) {
+        LocalDate today = LocalDate.now(SERVICE_ZONE_ID);
+
+        PageRequest pageRequest = PageRequest.of(0, MAX_DEADLINE_SIZE);
+
+        List<Policy> policies = policyLikeRepository.findUpcomingDeadlineLikedPolicies(
+                        user.getId(),
+                        RecruitmentStatus.CLOSED,
+                        today,
+                        pageRequest
+                );
+
+        Set<Long> likedPolicyIds = policies.stream()
+                .map(Policy::getId)
+                .collect(Collectors.toSet());
+
+        List<PolicySummary> policySummaries = policyDisplayMapper.toSummaries(policies, likedPolicyIds);
+        return new MyPolicyDeadlineResponse(policySummaries);
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/policy/application/MyPolicyService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/MyPolicyService.java
@@ -9,10 +9,9 @@ import com.chungbazi.server.domain.policy.application.mapper.PolicyListResponseA
 import com.chungbazi.server.domain.policy.application.mapper.PolicyDisplayMapper;
 import com.chungbazi.server.domain.policy.domain.entity.Policy;
 import com.chungbazi.server.domain.policy.domain.repository.PolicyLikeRepository;
+import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
 import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
-import com.chungbazi.server.domain.policy.exception.PolicyErrorCode;
-import com.chungbazi.server.domain.policy.exception.PolicyException;
 import com.chungbazi.server.domain.user.domain.User;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -57,16 +56,16 @@ public class MyPolicyService {
         return new MyPolicyDeadlineResponse(policySummaries);
     }
 
-    public PolicyListResponse getDeadlinePoliciesByDate(User user, LocalDate targetDate, PolicySortType sort, String cursor, int size) {
-        validateDeadlineDateSort(sort);
+    public PolicyListResponse getDeadlinePoliciesByDate(User user, LocalDate targetDate, PolicyListSortType sort, String cursor, int size) {
+        PolicySortType policySort = sort.getPolicySortType();
 
-        PolicyCursor decodedCursor = PolicyCursorParser.decode(cursor, sort);
+        PolicyCursor decodedCursor = PolicyCursorParser.decode(cursor, policySort);
         PageRequest pageRequest = PageRequest.of(0, size + 1);
 
         List<Policy> fetchedPolicies = fetchDeadlinePoliciesByDate(
                 user.getId(),
                 targetDate,
-                sort,
+                policySort,
                 decodedCursor,
                 pageRequest
         );
@@ -81,7 +80,7 @@ public class MyPolicyService {
                 .collect(Collectors.toSet());
 
         String nextCursor = hasNext
-                ? PolicyCursorParser.encode(sort, policies.getLast())
+                ? PolicyCursorParser.encode(policySort, policies.getLast())
                 : null;
 
         Long totalCount = policyLikeRepository.countDeadlineLikedPoliciesByDate(
@@ -137,9 +136,4 @@ public class MyPolicyService {
         );
     }
 
-    private void validateDeadlineDateSort(PolicySortType sort) {
-        if (sort == PolicySortType.POPULAR) {
-            throw new PolicyException(PolicyErrorCode.INVALID_POLICY_SORT);
-        }
-    }
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/application/MyPolicyService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/MyPolicyService.java
@@ -8,10 +8,14 @@ import com.chungbazi.server.domain.policy.application.cursor.PolicyCursorParser;
 import com.chungbazi.server.domain.policy.application.mapper.PolicyListResponseAssembler;
 import com.chungbazi.server.domain.policy.application.mapper.PolicyDisplayMapper;
 import com.chungbazi.server.domain.policy.domain.entity.Policy;
+import com.chungbazi.server.domain.policy.domain.entity.PolicyLike;
 import com.chungbazi.server.domain.policy.domain.repository.PolicyLikeRepository;
 import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
+import com.chungbazi.server.domain.policy.domain.type.RecruitmentType;
 import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
+import com.chungbazi.server.domain.policy.exception.PolicyErrorCode;
+import com.chungbazi.server.domain.policy.exception.PolicyException;
 import com.chungbazi.server.domain.user.domain.User;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -136,4 +140,79 @@ public class MyPolicyService {
         );
     }
 
+    public PolicyListResponse getOpenEndedLikedPolicies(User user, String cursor, int size) {
+        Long decodedCursor = decodePolicyLikeIdCursor(cursor);
+        PageRequest pageRequest = PageRequest.of(0, size + 1);
+
+        List<PolicyLike> fetchedPolicyLikes = fetchOpenEndedLikedPolicies(
+                user.getId(),
+                decodedCursor,
+                pageRequest
+        );
+
+        boolean hasNext = fetchedPolicyLikes.size() > size;
+        List<PolicyLike> policyLikes = hasNext
+                ? new ArrayList<>(fetchedPolicyLikes.subList(0, size))
+                : fetchedPolicyLikes;
+
+        List<Policy> policies = policyLikes.stream()
+                .map(PolicyLike::getPolicy)
+                .toList();
+
+        Set<Long> likedPolicyIds = policies.stream()
+                .map(Policy::getId)
+                .collect(Collectors.toSet());
+
+        String nextCursor = hasNext
+                ? policyLikes.getLast().getId().toString()
+                : null;
+
+        Long totalCount = policyLikeRepository.countOpenEndedLikedPolicies(
+                user.getId(),
+                RecruitmentStatus.CLOSED,
+                RecruitmentType.ALWAYS
+        );
+
+        return policyListResponseAssembler.assemble(
+                totalCount,
+                policyListResponseAssembler.summarize(policies, likedPolicyIds),
+                nextCursor,
+                hasNext
+        );
+    }
+
+    private List<PolicyLike> fetchOpenEndedLikedPolicies(
+            Long userId,
+            Long cursor,
+            PageRequest pageRequest
+    ) {
+        if (cursor == null) {
+            return policyLikeRepository.findOpenEndedLikedPoliciesFirst(
+                    userId,
+                    RecruitmentStatus.CLOSED,
+                    RecruitmentType.ALWAYS,
+                    pageRequest
+            );
+        }
+
+        return policyLikeRepository.findOpenEndedLikedPoliciesAfter(
+                userId,
+                RecruitmentStatus.CLOSED,
+                RecruitmentType.ALWAYS,
+                cursor,
+                pageRequest
+        );
+    }
+
+    private Long decodePolicyLikeIdCursor(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;
+        }
+
+        try {
+            return Long.valueOf(cursor);
+        } catch (NumberFormatException exception) {
+            throw new PolicyException(PolicyErrorCode.INVALID_POLICY_CURSOR);
+        }
+    }
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/application/MyPolicyService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/MyPolicyService.java
@@ -50,6 +50,7 @@ public class MyPolicyService {
         List<Policy> policies = policyLikeRepository.findUpcomingDeadlineLikedPolicies(
                         user.getId(),
                         RecruitmentStatus.CLOSED,
+                        RecruitmentType.ALWAYS,
                         today,
                         pageRequest
                 );

--- a/src/main/java/com/chungbazi/server/domain/policy/application/PolicySearchService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/PolicySearchService.java
@@ -13,6 +13,7 @@ import com.chungbazi.server.domain.policy.domain.entity.RecentSearchKeyword;
 import com.chungbazi.server.domain.policy.domain.repository.RecentSearchKeywordRepository;
 import com.chungbazi.server.domain.policy.domain.repository.policyRepository.PolicyRepository;
 import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
+import com.chungbazi.server.domain.policy.domain.type.PolicyListSortType;
 import com.chungbazi.server.domain.policy.domain.type.PolicySortType;
 import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
 import com.chungbazi.server.domain.policy.exception.PolicyErrorCode;
@@ -42,12 +43,13 @@ public class PolicySearchService {
             User user,
             String keyword,
             PolicyCategoryType category,
-            PolicySortType sort,
+            PolicyListSortType sort,
             String cursor,
             int size
     ) {
         String normalizedKeyword = normalizeKeyword(keyword);
-        PolicyCursor decodedCursor = PolicyCursorParser.decode(cursor, sort);
+        PolicySortType policySort = sort.getPolicySortType();
+        PolicyCursor decodedCursor = PolicyCursorParser.decode(cursor, policySort);
         // 최근 검색어 저장
         if (user.isSearchKeywordAutoSaveEnabled()) {
             saveRecentSearchKeyword(user, normalizedKeyword);
@@ -56,7 +58,7 @@ public class PolicySearchService {
         List<Policy> fetchedPolicies = policyRepository.searchPolicies(
                 normalizedKeyword,
                 category,
-                sort,
+                policySort,
                 RecruitmentStatus.CLOSED,
                 user.getSidoCode(),
                 user.getSigunguCode(),
@@ -73,7 +75,7 @@ public class PolicySearchService {
                 user.getSidoCode(),
                 user.getSigunguCode()
         );
-        return policyListResponseAssembler.assemble(user, sort, fetchedPolicies, totalCount, size);
+        return policyListResponseAssembler.assemble(user, policySort, fetchedPolicies, totalCount, size);
     }
 
     public SearchSuggestionResponse getSearchSuggestions(User user, String keyword) {

--- a/src/main/java/com/chungbazi/server/domain/policy/application/cursor/PolicyCursorParser.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/cursor/PolicyCursorParser.java
@@ -52,6 +52,19 @@ public final class PolicyCursorParser {
                 .encodeToString(rawCursor.getBytes(StandardCharsets.UTF_8));
     }
 
+    public static String encodeOpenEndedDeadline(Long policyId) {
+        String rawCursor = String.join(
+                CURSOR_JOINER,
+                PolicySortType.DEADLINE.name(),
+                NULL_DATE,
+                policyId.toString()
+        );
+
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(rawCursor.getBytes(StandardCharsets.UTF_8));
+    }
+
     public static PolicyCursor decode(String encodedCursor, PolicySortType requestedSort) {
         if (encodedCursor == null || encodedCursor.isBlank()) {
             return null;

--- a/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
@@ -266,7 +266,7 @@ public interface PolicyLikeRepository extends JpaRepository<PolicyLike, Long> {
               AND (:category IS NULL OR policy.category = :category)
             ORDER BY
               CASE WHEN policy.recruitmentType = :openEndedType OR policy.applyEndDate IS NULL THEN 1 ELSE 0 END ASC,
-              policy.applyEndDate ASC,
+              CASE WHEN policy.recruitmentType = :openEndedType OR policy.applyEndDate IS NULL THEN NULL ELSE policy.applyEndDate END ASC,
               policy.id DESC
             """)
     List<Policy> findMyLikedPoliciesOrderByDeadlineFirst(
@@ -292,7 +292,7 @@ public interface PolicyLikeRepository extends JpaRepository<PolicyLike, Long> {
               )
             ORDER BY
               CASE WHEN policy.recruitmentType = :openEndedType OR policy.applyEndDate IS NULL THEN 1 ELSE 0 END ASC,
-              policy.applyEndDate ASC,
+              CASE WHEN policy.recruitmentType = :openEndedType OR policy.applyEndDate IS NULL THEN NULL ELSE policy.applyEndDate END ASC,
               policy.id DESC
             """)
     List<Policy> findMyLikedPoliciesOrderByDeadlineAfterDatedCursor(

--- a/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
@@ -2,6 +2,7 @@ package com.chungbazi.server.domain.policy.domain.repository;
 
 import com.chungbazi.server.domain.policy.domain.entity.Policy;
 import com.chungbazi.server.domain.policy.domain.entity.PolicyLike;
+import com.chungbazi.server.domain.policy.domain.type.RecruitmentType;
 import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -150,6 +151,54 @@ public interface PolicyLikeRepository extends JpaRepository<PolicyLike, Long> {
             @Param("closedStatus") RecruitmentStatus closedStatus,
             @Param("targetDate") LocalDate targetDate,
             @Param("policyId") Long policyId,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT COUNT(policyLike)
+            FROM PolicyLike policyLike
+            JOIN policyLike.policy policy
+            WHERE policyLike.userId = :userId
+              AND policy.recruitmentStatus <> :closedStatus
+              AND policy.recruitmentType = :recruitmentType
+            """)
+    Long countOpenEndedLikedPolicies(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("recruitmentType") RecruitmentType recruitmentType
+    );
+
+    @Query("""
+            SELECT policyLike
+            FROM PolicyLike policyLike
+            JOIN FETCH policyLike.policy policy
+            WHERE policyLike.userId = :userId
+              AND policy.recruitmentStatus <> :closedStatus
+              AND policy.recruitmentType = :recruitmentType
+            ORDER BY policyLike.id DESC
+            """)
+    List<PolicyLike> findOpenEndedLikedPoliciesFirst(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("recruitmentType") RecruitmentType recruitmentType,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT policyLike
+            FROM PolicyLike policyLike
+            JOIN FETCH policyLike.policy policy
+            WHERE policyLike.userId = :userId
+              AND policy.recruitmentStatus <> :closedStatus
+              AND policy.recruitmentType = :recruitmentType
+              AND policyLike.id < :cursorId
+            ORDER BY policyLike.id DESC
+            """)
+    List<PolicyLike> findOpenEndedLikedPoliciesAfter(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("recruitmentType") RecruitmentType recruitmentType,
+            @Param("policyLikeId") Long policyLikeId,
             Pageable pageable
     );
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
@@ -4,6 +4,7 @@ import com.chungbazi.server.domain.policy.domain.entity.Policy;
 import com.chungbazi.server.domain.policy.domain.entity.PolicyLike;
 import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
@@ -63,6 +64,92 @@ public interface PolicyLikeRepository extends JpaRepository<PolicyLike, Long> {
             @Param("userId") Long userId,
             @Param("closedStatus") RecruitmentStatus closedStatus,
             @Param("today") LocalDate today,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT COUNT(policy)
+            FROM PolicyLike policyLike
+            JOIN policyLike.policy policy
+            WHERE policyLike.userId = :userId
+              AND policy.recruitmentStatus <> :closedStatus
+              AND policy.applyEndDate = :targetDate
+            """)
+    Long countDeadlineLikedPoliciesByDate(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("targetDate") LocalDate targetDate
+    );
+
+    @Query("""
+            SELECT policy
+            FROM PolicyLike policyLike
+            JOIN policyLike.policy policy
+            WHERE policyLike.userId = :userId
+              AND policy.recruitmentStatus <> :closedStatus
+              AND policy.applyEndDate = :targetDate
+            ORDER BY policy.registeredAt DESC, policy.id DESC
+            """)
+    List<Policy> findDeadlineLikedPoliciesByDateOrderByLatestFirst(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("targetDate") LocalDate targetDate,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT policy
+            FROM PolicyLike policyLike
+            JOIN policyLike.policy policy
+            WHERE policyLike.userId = :userId
+              AND policy.recruitmentStatus <> :closedStatus
+              AND policy.applyEndDate = :targetDate
+              AND (
+                  policy.registeredAt < :registeredAt
+                  OR (policy.registeredAt = :registeredAt AND policy.id < :policyId)
+              )
+            ORDER BY policy.registeredAt DESC, policy.id DESC
+            """)
+    List<Policy> findDeadlineLikedPoliciesByDateOrderByLatestAfter(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("targetDate") LocalDate targetDate,
+            @Param("registeredAt") LocalDateTime registeredAt,
+            @Param("policyId") Long policyId,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT policy
+            FROM PolicyLike policyLike
+            JOIN policyLike.policy policy
+            WHERE policyLike.userId = :userId
+              AND policy.recruitmentStatus <> :closedStatus
+              AND policy.applyEndDate = :targetDate
+            ORDER BY policy.applyEndDate ASC, policy.id DESC
+            """)
+    List<Policy> findDeadlineLikedPoliciesByDateOrderByDeadlineFirst(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("targetDate") LocalDate targetDate,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT policy
+            FROM PolicyLike policyLike
+            JOIN policyLike.policy policy
+            WHERE policyLike.userId = :userId
+              AND policy.recruitmentStatus <> :closedStatus
+              AND policy.applyEndDate = :targetDate
+              AND policy.id < :policyId
+            ORDER BY policy.applyEndDate ASC, policy.id DESC
+            """)
+    List<Policy> findDeadlineLikedPoliciesByDateOrderByDeadlineAfter(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("targetDate") LocalDate targetDate,
+            @Param("policyId") Long policyId,
             Pageable pageable
     );
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
@@ -1,6 +1,9 @@
 package com.chungbazi.server.domain.policy.domain.repository;
 
+import com.chungbazi.server.domain.policy.domain.entity.Policy;
 import com.chungbazi.server.domain.policy.domain.entity.PolicyLike;
+import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
@@ -43,6 +46,23 @@ public interface PolicyLikeRepository extends JpaRepository<PolicyLike, Long> {
             """)
     List<PolicyLike> findRecentPolicyLikesWithPolicy(
             @Param("userId") Long userId,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT policy
+            FROM PolicyLike policyLike
+            JOIN policyLike.policy policy
+            WHERE policyLike.userId = :userId
+              AND policy.recruitmentStatus <> :closedStatus
+              AND policy.applyEndDate IS NOT NULL
+              AND policy.applyEndDate >= :today
+            ORDER BY policy.applyEndDate ASC, policy.id DESC
+            """)
+    List<Policy> findUpcomingDeadlineLikedPolicies(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("today") LocalDate today,
             Pageable pageable
     );
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
@@ -58,6 +58,7 @@ public interface PolicyLikeRepository extends JpaRepository<PolicyLike, Long> {
             JOIN policyLike.policy policy
             WHERE policyLike.userId = :userId
               AND policy.recruitmentStatus <> :closedStatus
+              AND policy.recruitmentType <> :openEndedType
               AND policy.applyEndDate IS NOT NULL
               AND policy.applyEndDate >= :today
             ORDER BY policy.applyEndDate ASC, policy.id DESC
@@ -65,6 +66,7 @@ public interface PolicyLikeRepository extends JpaRepository<PolicyLike, Long> {
     List<Policy> findUpcomingDeadlineLikedPolicies(
             @Param("userId") Long userId,
             @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("openEndedType") RecruitmentType openEndedType,
             @Param("today") LocalDate today,
             Pageable pageable
     );

--- a/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
@@ -2,6 +2,7 @@ package com.chungbazi.server.domain.policy.domain.repository;
 
 import com.chungbazi.server.domain.policy.domain.entity.Policy;
 import com.chungbazi.server.domain.policy.domain.entity.PolicyLike;
+import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
 import com.chungbazi.server.domain.policy.domain.type.RecruitmentType;
 import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
 import java.time.LocalDate;
@@ -191,7 +192,7 @@ public interface PolicyLikeRepository extends JpaRepository<PolicyLike, Long> {
             WHERE policyLike.userId = :userId
               AND policy.recruitmentStatus <> :closedStatus
               AND policy.recruitmentType = :recruitmentType
-              AND policyLike.id < :cursorId
+              AND policyLike.id < :policyLikeId
             ORDER BY policyLike.id DESC
             """)
     List<PolicyLike> findOpenEndedLikedPoliciesAfter(
@@ -199,6 +200,126 @@ public interface PolicyLikeRepository extends JpaRepository<PolicyLike, Long> {
             @Param("closedStatus") RecruitmentStatus closedStatus,
             @Param("recruitmentType") RecruitmentType recruitmentType,
             @Param("policyLikeId") Long policyLikeId,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT COUNT(policy)
+            FROM PolicyLike policyLike
+            JOIN policyLike.policy policy
+            WHERE policyLike.userId = :userId
+              AND policy.recruitmentStatus <> :closedStatus
+              AND (:category IS NULL OR policy.category = :category)
+            """)
+    Long countMyLikedPolicies(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("category") PolicyCategoryType category
+    );
+
+    @Query("""
+            SELECT policy
+            FROM PolicyLike policyLike
+            JOIN policyLike.policy policy
+            WHERE policyLike.userId = :userId
+              AND policy.recruitmentStatus <> :closedStatus
+              AND (:category IS NULL OR policy.category = :category)
+            ORDER BY policy.registeredAt DESC, policy.id DESC
+            """)
+    List<Policy> findMyLikedPoliciesOrderByLatestFirst(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("category") PolicyCategoryType category,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT policy
+            FROM PolicyLike policyLike
+            JOIN policyLike.policy policy
+            WHERE policyLike.userId = :userId
+              AND policy.recruitmentStatus <> :closedStatus
+              AND (:category IS NULL OR policy.category = :category)
+              AND (
+                  policy.registeredAt < :registeredAt
+                  OR (policy.registeredAt = :registeredAt AND policy.id < :policyId)
+              )
+            ORDER BY policy.registeredAt DESC, policy.id DESC
+            """)
+    List<Policy> findMyLikedPoliciesOrderByLatestAfter(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("category") PolicyCategoryType category,
+            @Param("registeredAt") LocalDateTime registeredAt,
+            @Param("policyId") Long policyId,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT policy
+            FROM PolicyLike policyLike
+            JOIN policyLike.policy policy
+            WHERE policyLike.userId = :userId
+              AND policy.recruitmentStatus <> :closedStatus
+              AND (:category IS NULL OR policy.category = :category)
+            ORDER BY
+              CASE WHEN policy.recruitmentType = :openEndedType OR policy.applyEndDate IS NULL THEN 1 ELSE 0 END ASC,
+              policy.applyEndDate ASC,
+              policy.id DESC
+            """)
+    List<Policy> findMyLikedPoliciesOrderByDeadlineFirst(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("category") PolicyCategoryType category,
+            @Param("openEndedType") RecruitmentType openEndedType,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT policy
+            FROM PolicyLike policyLike
+            JOIN policyLike.policy policy
+            WHERE policyLike.userId = :userId
+              AND policy.recruitmentStatus <> :closedStatus
+              AND (:category IS NULL OR policy.category = :category)
+              AND (
+                  policy.applyEndDate > :applyEndDate
+                  OR (policy.applyEndDate = :applyEndDate AND policy.id < :policyId)
+                  OR policy.applyEndDate IS NULL
+                  OR policy.recruitmentType = :openEndedType
+              )
+            ORDER BY
+              CASE WHEN policy.recruitmentType = :openEndedType OR policy.applyEndDate IS NULL THEN 1 ELSE 0 END ASC,
+              policy.applyEndDate ASC,
+              policy.id DESC
+            """)
+    List<Policy> findMyLikedPoliciesOrderByDeadlineAfterDatedCursor(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("category") PolicyCategoryType category,
+            @Param("openEndedType") RecruitmentType openEndedType,
+            @Param("applyEndDate") LocalDate applyEndDate,
+            @Param("policyId") Long policyId,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT policy
+            FROM PolicyLike policyLike
+            JOIN policyLike.policy policy
+            WHERE policyLike.userId = :userId
+              AND policy.recruitmentStatus <> :closedStatus
+              AND (:category IS NULL OR policy.category = :category)
+              AND (policy.recruitmentType = :openEndedType OR policy.applyEndDate IS NULL)
+              AND policy.id < :policyId
+            ORDER BY policy.id DESC
+            """)
+    List<Policy> findMyLikedPoliciesOrderByDeadlineAfterOpenEndedCursor(
+            @Param("userId") Long userId,
+            @Param("closedStatus") RecruitmentStatus closedStatus,
+            @Param("category") PolicyCategoryType category,
+            @Param("openEndedType") RecruitmentType openEndedType,
+            @Param("policyId") Long policyId,
             Pageable pageable
     );
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/domain/type/PolicyListSortType.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/domain/type/PolicyListSortType.java
@@ -1,0 +1,14 @@
+package com.chungbazi.server.domain.policy.domain.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PolicyListSortType {
+    LATEST("최신순", PolicySortType.LATEST),
+    DEADLINE("마감순", PolicySortType.DEADLINE);
+
+    private final String description;
+    private final PolicySortType policySortType;
+}

--- a/src/main/java/com/chungbazi/server/domain/policy/exception/PolicyErrorCode.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/exception/PolicyErrorCode.java
@@ -16,6 +16,7 @@ public enum PolicyErrorCode implements BaseErrorCode {
     INVALID_POLICY_CURSOR(HttpStatus.BAD_REQUEST, "POLICY4005", "유효하지 않은 정책 조회 커서입니다."),
     INVALID_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, "POLICY4006", "검색어를 입력해주세요."),
     INVALID_RECENT_SEARCH_KEYWORD_CURSOR(HttpStatus.BAD_REQUEST, "POLICY4007", "유효하지 않은 최근 검색어 조회 커서입니다."),
+    INVALID_POLICY_SORT(HttpStatus.BAD_REQUEST, "POLICY4008", "유효하지 않은 정책 정렬 기준입니다."),
     POLICY_NOT_FOUND(HttpStatus.NOT_FOUND, "POLICY4040", "정책을 찾을 수 없습니다."),
     RECENT_SEARCH_KEYWORD_NOT_FOUND( HttpStatus.NOT_FOUND, "POLICY4041", "최근 검색어를 찾을 수 없습니다."),
     REGION_NOT_INITIALIZED(HttpStatus.INTERNAL_SERVER_ERROR, "POLICY5001", "시군구 코드 데이터가 초기화되지 않았습니다."),

--- a/src/main/java/com/chungbazi/server/domain/policy/exception/PolicyErrorCode.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/exception/PolicyErrorCode.java
@@ -16,7 +16,6 @@ public enum PolicyErrorCode implements BaseErrorCode {
     INVALID_POLICY_CURSOR(HttpStatus.BAD_REQUEST, "POLICY4005", "유효하지 않은 정책 조회 커서입니다."),
     INVALID_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, "POLICY4006", "검색어를 입력해주세요."),
     INVALID_RECENT_SEARCH_KEYWORD_CURSOR(HttpStatus.BAD_REQUEST, "POLICY4007", "유효하지 않은 최근 검색어 조회 커서입니다."),
-    INVALID_POLICY_SORT(HttpStatus.BAD_REQUEST, "POLICY4008", "유효하지 않은 정책 정렬 기준입니다."),
     POLICY_NOT_FOUND(HttpStatus.NOT_FOUND, "POLICY4040", "정책을 찾을 수 없습니다."),
     RECENT_SEARCH_KEYWORD_NOT_FOUND( HttpStatus.NOT_FOUND, "POLICY4041", "최근 검색어를 찾을 수 없습니다."),
     REGION_NOT_INITIALIZED(HttpStatus.INTERNAL_SERVER_ERROR, "POLICY5001", "시군구 코드 데이터가 초기화되지 않았습니다."),

--- a/src/main/java/com/chungbazi/server/domain/policy/infrastructure/external/youthpolicy/mapper/YouthPolicyDateMapper.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/infrastructure/external/youthpolicy/mapper/YouthPolicyDateMapper.java
@@ -116,7 +116,7 @@ public class YouthPolicyDateMapper {
         return createDatedPeriod(
                 parsedPeriod.dateRange(),
                 parsedPeriod.periodText(),
-                RecruitmentType.ALWAYS
+                RecruitmentType.FIXED_PERIOD
         );
     }
 

--- a/src/test/java/com/chungbazi/server/domain/policy/infrastructure/external/youthpolicy/mapper/YouthPolicyDateMapperTest.java
+++ b/src/test/java/com/chungbazi/server/domain/policy/infrastructure/external/youthpolicy/mapper/YouthPolicyDateMapperTest.java
@@ -29,7 +29,7 @@ class YouthPolicyDateMapperTest {
     }
 
     @Test
-    void mapsAlwaysOpenPeriodFromSeparateBusinessDates() {
+    void mapsAlwaysOpenCodeWithSeparateBusinessDatesAsFixedPeriod() {
         ApplyPeriod result = map(
                 YouthPolicyDateMapper.ALWAYS_OPEN_CODE,
                 null,
@@ -40,11 +40,11 @@ class YouthPolicyDateMapperTest {
 
         assertThat(result.startDate()).isEqualTo(LocalDate.of(2026, 1, 1));
         assertThat(result.endDate()).isEqualTo(LocalDate.of(2026, 12, 31));
-        assertThat(result.recruitmentType()).isEqualTo(RecruitmentType.ALWAYS);
+        assertThat(result.recruitmentType()).isEqualTo(RecruitmentType.FIXED_PERIOD);
     }
 
     @Test
-    void mapsAlwaysOpenRangeStoredInBusinessPeriodText() {
+    void mapsAlwaysOpenCodeWithRangeStoredInBusinessPeriodTextAsFixedPeriod() {
         ApplyPeriod result = map(
                 YouthPolicyDateMapper.ALWAYS_OPEN_CODE,
                 null,
@@ -55,11 +55,11 @@ class YouthPolicyDateMapperTest {
 
         assertThat(result.startDate()).isEqualTo(LocalDate.of(2026, 1, 1));
         assertThat(result.endDate()).isEqualTo(LocalDate.of(2026, 12, 31));
-        assertThat(result.recruitmentType()).isEqualTo(RecruitmentType.ALWAYS);
+        assertThat(result.recruitmentType()).isEqualTo(RecruitmentType.FIXED_PERIOD);
     }
 
     @Test
-    void mapsAnnualAlwaysOpenPeriodUsingBusinessYear() {
+    void mapsAnnualAlwaysOpenPeriodUsingBusinessYearAsFixedPeriod() {
         ApplyPeriod result = map(
                 YouthPolicyDateMapper.ALWAYS_OPEN_CODE,
                 null,
@@ -70,11 +70,11 @@ class YouthPolicyDateMapperTest {
 
         assertThat(result.startDate()).isEqualTo(LocalDate.of(2026, 1, 1));
         assertThat(result.endDate()).isEqualTo(LocalDate.of(2026, 12, 31));
-        assertThat(result.recruitmentType()).isEqualTo(RecruitmentType.ALWAYS);
+        assertThat(result.recruitmentType()).isEqualTo(RecruitmentType.FIXED_PERIOD);
     }
 
     @Test
-    void mapsAlwaysOpenYearMonthRange() {
+    void mapsAlwaysOpenCodeWithYearMonthRangeAsFixedPeriod() {
         ApplyPeriod result = map(
                 YouthPolicyDateMapper.ALWAYS_OPEN_CODE,
                 null,
@@ -85,7 +85,7 @@ class YouthPolicyDateMapperTest {
 
         assertThat(result.startDate()).isEqualTo(LocalDate.of(2026, 1, 1));
         assertThat(result.endDate()).isEqualTo(LocalDate.of(2026, 12, 31));
-        assertThat(result.recruitmentType()).isEqualTo(RecruitmentType.ALWAYS);
+        assertThat(result.recruitmentType()).isEqualTo(RecruitmentType.FIXED_PERIOD);
     }
 
     @Test
@@ -100,6 +100,7 @@ class YouthPolicyDateMapperTest {
 
         assertThat(result.startDate()).isEqualTo(LocalDate.of(2026, 3, 1));
         assertThat(result.endDate()).isEqualTo(LocalDate.of(2026, 11, 30));
+        assertThat(result.recruitmentType()).isEqualTo(RecruitmentType.FIXED_PERIOD);
     }
 
     @Test


### PR DESCRIPTION
## 🔗 연관된 이슈
- #36

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 마감이 다가오는 찜한 정책 조회 API
- 선택 날짜에 마감되는 정책 리스트 조회 API
- 찜한 상시모집 정책 리스트 조회 API
- 내 정책 전체보기 API 

## 📸 스크린샷
### 내 정책 전체보기 API
<img width="1013" height="443" alt="image" src="https://github.com/user-attachments/assets/071cc024-4023-4a43-9d9a-136f1c5f518f" />

### 찜한 상시모집 정책 리스트 조회 API
<img width="1024" height="442" alt="image" src="https://github.com/user-attachments/assets/f2e368ee-683a-42d0-af02-042bea3be0de" />

### 선택 날짜에 마감되는 정책 리스트 조회 API
<img width="1027" height="449" alt="image" src="https://github.com/user-attachments/assets/024c0f0e-e4e6-4193-a8be-a354fdd4f2e8" />
정렬을 보니, 기존에 연중 정책을 상시정책으로 저장하면서 enddate도 같이 저장되며 생긴 문제 같습니다. 해당 부분 관련해서 리뷰 요구사항에 올려두겠습니다!

### 마감이 다가오는 찜한 정책 조회 API
<img width="1027" height="443" alt="image" src="https://github.com/user-attachments/assets/1e5ec3db-6b5e-4920-b6e9-3dbababa470f" />


## ✅ 체크리스트
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 테스트 시 사용한 로그를 삭제했습니다.

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 중간에 정렬 enum 수정해서, 파일이 여러개 수정됐는데 리뷰할 때 보기 힘드시면 커밋단위로 보시면 될 거 같습니다!
- 기존에는 연중 정책을 상시 정책으로 저장했었는데요, 상시보다는 기간 정책으로 저장하는 방식으로 바꾸려합니다 이에 관한 정빈님 의견이 궁금합니다!

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

> - **P1:** 꼭 반영해주세요 (Comment)
> - **P2:** 적극적으로 고려해주세요 (Comment)
> - **P3:** 웬만하면 반영해 주세요 (Comment)
> - **P4:** 반영해도 좋고 넘어가도 좋습니다 (Approve)
> - **P5:** 그냥 사소한 의견입니다 (Approve)

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 찜한 정책의 마감 임박 목록을 확인할 수 있습니다.
* 특정 날짜에 마감되는 찜한 정책을 조회할 수 있습니다.
* 마감일이 없는 상시 모집 정책을 별도로 확인할 수 있습니다.
* 카테고리별 찜한 정책 조회를 지원합니다.
* 정책 목록과 검색 결과에서 최신순·마감순 정렬을 선택할 수 있습니다.
* 정책 목록 조회에 커서 기반 페이지네이션이 적용되었습니다.

## 문서
* 새 정책 조회 기능의 API 문서와 응답 형식이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->