### PR TITLE
[Feat] FCM 토큰 파이프라인 최적화 & 정책 리마인드 알림 및 FCM 발송 구현

### DIFF
--- a/scripts/migrations/add_fcm_token_unique_constraint.sql
+++ b/scripts/migrations/add_fcm_token_unique_constraint.sql
@@ -1,0 +1,16 @@
+CREATE TEMPORARY TABLE duplicate_fcm_tokens AS
+SELECT fcm_token
+FROM `user`
+WHERE fcm_token IS NOT NULL
+GROUP BY fcm_token
+HAVING COUNT(*) > 1;
+
+UPDATE `user` AS target_user
+JOIN duplicate_fcm_tokens AS duplicate
+    ON target_user.fcm_token = duplicate.fcm_token
+SET target_user.fcm_token = NULL;
+
+DROP TEMPORARY TABLE duplicate_fcm_tokens;
+
+ALTER TABLE `user`
+    ADD CONSTRAINT uk_user_fcm_token UNIQUE (fcm_token);

--- a/scripts/migrations/add_notification_type.sql
+++ b/scripts/migrations/add_notification_type.sql
@@ -1,0 +1,6 @@
+ALTER TABLE notification
+    ADD COLUMN notification_type VARCHAR(40) NOT NULL DEFAULT 'UNKNOWN'
+    AFTER notification_category;
+
+ALTER TABLE notification
+    MODIFY COLUMN notification_type VARCHAR(40) NOT NULL;

--- a/src/main/java/com/chungbazi/server/domain/auth/api/AuthController.java
+++ b/src/main/java/com/chungbazi/server/domain/auth/api/AuthController.java
@@ -48,7 +48,7 @@ public class AuthController implements AuthDocs {
             @CurrentUser User user,
             @Parameter(hidden = true) @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization
     ) {
-        authService.logout(user.getId(), BearerTokenExtractor.extract(authorization));
+        authService.logout(user, BearerTokenExtractor.extract(authorization));
         return CommonResponse.onSuccess("로그아웃이 성공적으로 실행되었습니다.");
     }
 }

--- a/src/main/java/com/chungbazi/server/domain/auth/api/dto/request/AppleLoginRequest.java
+++ b/src/main/java/com/chungbazi/server/domain/auth/api/dto/request/AppleLoginRequest.java
@@ -25,6 +25,7 @@ public record AppleLoginRequest(
                 description = "현재 사용자 기기의 fcmToken",
                 example = "YYrt9DQdv2djk6Q..."
         )
+        @NotBlank
         String fcmToken
 ) {
 }

--- a/src/main/java/com/chungbazi/server/domain/auth/api/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/chungbazi/server/domain/auth/api/dto/request/KakaoLoginRequest.java
@@ -1,6 +1,7 @@
 package com.chungbazi.server.domain.auth.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
@@ -16,6 +17,7 @@ public record KakaoLoginRequest(
                 description = "현재 사용자 기기의 fcmToken",
                 example = "YYrt9DQdv2djk6Q..."
         )
+        @NotBlank
         String fcmToken
 ) {
 }

--- a/src/main/java/com/chungbazi/server/domain/auth/application/AuthService.java
+++ b/src/main/java/com/chungbazi/server/domain/auth/application/AuthService.java
@@ -101,10 +101,9 @@ public class AuthService {
                         providerId,
                         socialType,
                         email,
-                        name,
-                        fcmToken
+                        name
                 ));
-        user.updateFcmToken(fcmToken);
+        registerFcmToken(user, fcmToken);
 
         return user;
     }
@@ -115,10 +114,9 @@ public class AuthService {
                         tokenInfo.providerId(),
                         SocialType.APPLE,
                         resolveAppleEmail(tokenInfo.email()),
-                        resolveAppleName(name),
-                        fcmToken
+                        resolveAppleName(name)
                 ));
-        user.updateFcmToken(fcmToken);
+        registerFcmToken(user, fcmToken);
 
         return user;
     }
@@ -127,14 +125,18 @@ public class AuthService {
             String providerId,
             SocialType socialType,
             String email,
-            String name,
-            String fcmToken
+            String name
     ) {
         User user = userRepository.save(
-                User.create(providerId, socialType, email, name, fcmToken)
+                User.create(providerId, socialType, email, name, null)
         );
         notificationSettingRepository.save(NotificationSetting.create(user));
         return user;
+    }
+
+    private void registerFcmToken(User user, String fcmToken) {
+        userRepository.clearFcmTokenFromOtherUsers(fcmToken, user.getId());
+        user.updateFcmToken(fcmToken);
     }
 
     private AuthTokenResponse issueTokenResponse(User user) {

--- a/src/main/java/com/chungbazi/server/domain/auth/application/AuthService.java
+++ b/src/main/java/com/chungbazi/server/domain/auth/application/AuthService.java
@@ -79,13 +79,14 @@ public class AuthService {
     }
 
     @Transactional
-    public void logout(Long userId, String accessToken) {
+    public void logout(User user, String accessToken) {
         Duration remainingExpiration = jwtProvider.getRemainingExpiration(accessToken);
 
         if (!remainingExpiration.isZero()) {
             tokenBlacklist.add(accessToken, remainingExpiration);
         }
-        refreshTokenRepository.deleteById(userId);
+        refreshTokenRepository.deleteById(user.getId());
+        user.clearFcmToken();
     }
 
     private User loginOrSignUp(

--- a/src/main/java/com/chungbazi/server/domain/notification/application/NotificationReminderService.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/NotificationReminderService.java
@@ -4,6 +4,7 @@ import com.chungbazi.server.domain.notification.application.dto.DeadlineReminder
 import com.chungbazi.server.domain.notification.application.dto.NotificationKey;
 import com.chungbazi.server.domain.notification.application.dto.PolicyReminderTargets;
 import com.chungbazi.server.domain.notification.application.mapper.NotificationReminderMapper;
+import com.chungbazi.server.domain.notification.application.event.DeadlineReminderNotificationsCreatedEvent;
 import com.chungbazi.server.domain.notification.domain.Notification;
 import com.chungbazi.server.domain.notification.domain.repository.NotificationRepository;
 import com.chungbazi.server.domain.notification.domain.type.NotificationType;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +32,7 @@ public class NotificationReminderService {
     private final PolicyLikeRepository policyLikeRepository;
     private final NotificationRepository notificationRepository;
     private final NotificationReminderMapper notificationReminderMapper;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public DeadlineReminderCreationResult createDeadlineReminderNotifications(LocalDate today) {
@@ -63,6 +66,11 @@ public class NotificationReminderService {
                 .toList();
 
         notificationRepository.saveAll(notifications);
+        if (!notifications.isEmpty()) {
+            eventPublisher.publishEvent(DeadlineReminderNotificationsCreatedEvent.of(
+                    notificationReminderMapper.toPushMessages(notifications)
+            ));
+        }
         return creationResult(targets, notifications.size());
     }
 

--- a/src/main/java/com/chungbazi/server/domain/notification/application/NotificationReminderService.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/NotificationReminderService.java
@@ -1,0 +1,123 @@
+package com.chungbazi.server.domain.notification.application;
+
+import com.chungbazi.server.domain.notification.application.dto.DeadlineReminderCreationResult;
+import com.chungbazi.server.domain.notification.application.dto.NotificationKey;
+import com.chungbazi.server.domain.notification.application.dto.PolicyReminderTargets;
+import com.chungbazi.server.domain.notification.application.mapper.NotificationReminderMapper;
+import com.chungbazi.server.domain.notification.domain.Notification;
+import com.chungbazi.server.domain.notification.domain.repository.NotificationRepository;
+import com.chungbazi.server.domain.notification.domain.type.NotificationType;
+import com.chungbazi.server.domain.policy.domain.entity.Policy;
+import com.chungbazi.server.domain.policy.domain.entity.PolicyLike;
+import com.chungbazi.server.domain.policy.domain.repository.PolicyLikeRepository;
+import com.chungbazi.server.domain.policy.domain.repository.policyRepository.PolicyRepository;
+import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationReminderService {
+
+    private final PolicyRepository policyRepository;
+    private final PolicyLikeRepository policyLikeRepository;
+    private final NotificationRepository notificationRepository;
+    private final NotificationReminderMapper notificationReminderMapper;
+
+    @Transactional
+    public DeadlineReminderCreationResult createDeadlineReminderNotifications(LocalDate today) {
+        PolicyReminderTargets targets = findReminderTargetPolicies(today);
+        Map<Long, NotificationType> reminderTypeByPolicyId =
+                notificationReminderMapper.toReminderTypeByPolicyId(targets);
+
+        if (reminderTypeByPolicyId.isEmpty()) {
+            return creationResult(targets, 0);
+        }
+
+        List<PolicyLike> recipients = policyLikeRepository.findDeadlineReminderRecipients(
+                reminderTypeByPolicyId.keySet()
+        );
+
+        if (recipients.isEmpty()) {
+            return creationResult(targets, 0);
+        }
+
+        Set<NotificationKey> existingNotificationKeys = findExistingNotificationKeys(
+                recipients,
+                reminderTypeByPolicyId
+        );
+
+        List<Notification> notifications = recipients.stream()
+                .map(policyLike -> notificationReminderMapper.toDeadlineNotification(
+                        policyLike,
+                        reminderTypeByPolicyId.get(policyLike.getPolicy().getId())
+                ))
+                .filter(notification -> !existingNotificationKeys.contains(NotificationKey.from(notification)))
+                .toList();
+
+        notificationRepository.saveAll(notifications);
+        return creationResult(targets, notifications.size());
+    }
+
+    public PolicyReminderTargets findReminderTargetPolicies(LocalDate today) {
+        LocalDate deadlineInSevenDays = today.plusDays(7);
+        LocalDate deadlineInThreeDays = today.plusDays(3);
+
+        List<Policy> reminderTargetPolicies =
+                policyRepository.findAllByApplyEndDateInAndRecruitmentStatusNot(
+                        List.of(deadlineInSevenDays, deadlineInThreeDays),
+                        RecruitmentStatus.CLOSED
+                );
+
+        List<Policy> deadlineInSevenDaysPolicies = reminderTargetPolicies.stream()
+                .filter(policy -> deadlineInSevenDays.equals(policy.getApplyEndDate()))
+                .toList();
+        List<Policy> deadlineInThreeDaysPolicies = reminderTargetPolicies.stream()
+                .filter(policy -> deadlineInThreeDays.equals(policy.getApplyEndDate()))
+                .toList();
+
+        return PolicyReminderTargets.of(
+                deadlineInSevenDaysPolicies,
+                deadlineInThreeDaysPolicies
+        );
+    }
+
+    private Set<NotificationKey> findExistingNotificationKeys(
+            List<PolicyLike> recipients,
+            Map<Long, NotificationType> reminderTypeByPolicyId
+    ) {
+        Set<Long> userIds = new HashSet<>();
+        Set<Long> policyIds = new HashSet<>();
+        recipients.forEach(policyLike -> {
+            userIds.add(policyLike.getUserId());
+            policyIds.add(policyLike.getPolicy().getId());
+        });
+
+        return notificationRepository.findAllByUserIdInAndPolicyIdInAndTypeIn(
+                        userIds,
+                        policyIds,
+                        new HashSet<>(reminderTypeByPolicyId.values())
+                ).stream()
+                .map(NotificationKey::from)
+                .collect(java.util.stream.Collectors.toSet());
+    }
+
+    private DeadlineReminderCreationResult creationResult(
+            PolicyReminderTargets targets,
+            int createdNotificationCount
+    ) {
+        return DeadlineReminderCreationResult.of(
+                targets.deadlineInSevenDaysPolicies().size(),
+                targets.deadlineInThreeDaysPolicies().size(),
+                createdNotificationCount
+        );
+    }
+
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/application/NotificationReminderService.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/NotificationReminderService.java
@@ -3,8 +3,9 @@ package com.chungbazi.server.domain.notification.application;
 import com.chungbazi.server.domain.notification.application.dto.DeadlineReminderCreationResult;
 import com.chungbazi.server.domain.notification.application.dto.NotificationKey;
 import com.chungbazi.server.domain.notification.application.dto.PolicyReminderTargets;
+import com.chungbazi.server.domain.notification.application.dto.PreparationReminderCreationResult;
+import com.chungbazi.server.domain.notification.application.event.PolicyReminderNotificationsCreatedEvent;
 import com.chungbazi.server.domain.notification.application.mapper.NotificationReminderMapper;
-import com.chungbazi.server.domain.notification.application.event.DeadlineReminderNotificationsCreatedEvent;
 import com.chungbazi.server.domain.notification.domain.Notification;
 import com.chungbazi.server.domain.notification.domain.repository.NotificationRepository;
 import com.chungbazi.server.domain.notification.domain.type.NotificationType;
@@ -14,6 +15,8 @@ import com.chungbazi.server.domain.policy.domain.repository.PolicyLikeRepository
 import com.chungbazi.server.domain.policy.domain.repository.policyRepository.PolicyRepository;
 import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -54,7 +57,7 @@ public class NotificationReminderService {
 
         Set<NotificationKey> existingNotificationKeys = findExistingNotificationKeys(
                 recipients,
-                reminderTypeByPolicyId
+                new HashSet<>(reminderTypeByPolicyId.values())
         );
 
         List<Notification> notifications = recipients.stream()
@@ -67,7 +70,7 @@ public class NotificationReminderService {
 
         notificationRepository.saveAll(notifications);
         if (!notifications.isEmpty()) {
-            eventPublisher.publishEvent(DeadlineReminderNotificationsCreatedEvent.of(
+            eventPublisher.publishEvent(PolicyReminderNotificationsCreatedEvent.of(
                     notificationReminderMapper.toPushMessages(notifications)
             ));
         }
@@ -97,9 +100,53 @@ public class NotificationReminderService {
         );
     }
 
+    public List<PolicyLike> findPreparationReminderTargets(LocalDateTime executionTime) {
+        LocalDateTime currentHour = executionTime.truncatedTo(ChronoUnit.HOURS);
+        LocalDateTime likedUntil = currentHour.minusHours(24);
+        LocalDateTime likedFrom = likedUntil.minusHours(1);
+
+        return policyLikeRepository.findPreparationReminderTargets(
+                        likedFrom,
+                        likedUntil,
+                        RecruitmentStatus.CLOSED
+                ).stream()
+                .filter(this::hasMoreThanSevenDaysUntilDeadlineAtLikedDate)
+                .toList();
+    }
+
+    @Transactional
+    public PreparationReminderCreationResult createPreparationReminderNotifications(
+            LocalDateTime executionTime
+    ) {
+        List<PolicyLike> targets = findPreparationReminderTargets(executionTime);
+        if (targets.isEmpty()) {
+            return PreparationReminderCreationResult.of(0, 0);
+        }
+
+        Set<NotificationKey> existingNotificationKeys = findExistingNotificationKeys(
+                targets,
+                Set.of(NotificationType.POLICY_PREPARATION)
+        );
+
+        List<Notification> notifications = targets.stream()
+                .map(notificationReminderMapper::toPreparationNotification)
+                .filter(notification -> !existingNotificationKeys.contains(NotificationKey.from(notification)))
+                .toList();
+
+        notificationRepository.saveAll(notifications);
+
+        if (!notifications.isEmpty()) {
+            eventPublisher.publishEvent(PolicyReminderNotificationsCreatedEvent.of(
+                    notificationReminderMapper.toPushMessages(notifications)
+            ));
+        }
+
+        return PreparationReminderCreationResult.of(targets.size(), notifications.size());
+    }
+
     private Set<NotificationKey> findExistingNotificationKeys(
             List<PolicyLike> recipients,
-            Map<Long, NotificationType> reminderTypeByPolicyId
+            Set<NotificationType> notificationTypes
     ) {
         Set<Long> userIds = new HashSet<>();
         Set<Long> policyIds = new HashSet<>();
@@ -111,7 +158,7 @@ public class NotificationReminderService {
         return notificationRepository.findAllByUserIdInAndPolicyIdInAndTypeIn(
                         userIds,
                         policyIds,
-                        new HashSet<>(reminderTypeByPolicyId.values())
+                        notificationTypes
                 ).stream()
                 .map(NotificationKey::from)
                 .collect(java.util.stream.Collectors.toSet());
@@ -126,6 +173,16 @@ public class NotificationReminderService {
                 targets.deadlineInThreeDaysPolicies().size(),
                 createdNotificationCount
         );
+    }
+
+    private boolean hasMoreThanSevenDaysUntilDeadlineAtLikedDate(PolicyLike policyLike) {
+        LocalDate applyEndDate = policyLike.getPolicy().getApplyEndDate();
+        if (applyEndDate == null) {
+            return true;
+        }
+
+        LocalDate sevenDaysAfterLikedDate = policyLike.getCreatedAt().toLocalDate().plusDays(7);
+        return applyEndDate.isAfter(sevenDaysAfterLikedDate);
     }
 
 }

--- a/src/main/java/com/chungbazi/server/domain/notification/application/dto/DeadlineReminderCreationResult.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/dto/DeadlineReminderCreationResult.java
@@ -1,0 +1,19 @@
+package com.chungbazi.server.domain.notification.application.dto;
+
+public record DeadlineReminderCreationResult(
+        int deadlineInSevenDaysPolicyCount,
+        int deadlineInThreeDaysPolicyCount,
+        int createdNotificationCount
+) {
+    public static DeadlineReminderCreationResult of(
+            int deadlineInSevenDaysPolicyCount,
+            int deadlineInThreeDaysPolicyCount,
+            int createdNotificationCount
+    ) {
+        return new DeadlineReminderCreationResult(
+                deadlineInSevenDaysPolicyCount,
+                deadlineInThreeDaysPolicyCount,
+                createdNotificationCount
+        );
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/application/dto/NotificationKey.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/dto/NotificationKey.java
@@ -1,0 +1,18 @@
+package com.chungbazi.server.domain.notification.application.dto;
+
+import com.chungbazi.server.domain.notification.domain.Notification;
+import com.chungbazi.server.domain.notification.domain.type.NotificationType;
+
+public record NotificationKey(
+        Long userId,
+        Long policyId,
+        NotificationType type
+) {
+    public static NotificationKey from(Notification notification) {
+        return new NotificationKey(
+                notification.getUserId(),
+                notification.getPolicyId(),
+                notification.getType()
+        );
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/application/dto/NotificationPushMessage.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/dto/NotificationPushMessage.java
@@ -1,0 +1,24 @@
+package com.chungbazi.server.domain.notification.application.dto;
+
+import com.chungbazi.server.domain.notification.domain.Notification;
+import com.chungbazi.server.domain.notification.domain.type.NotificationCategory;
+
+public record NotificationPushMessage(
+        Long notificationId,
+        Long userId,
+        NotificationCategory category,
+        String title,
+        String message,
+        Long policyId
+) {
+    public static NotificationPushMessage from(Notification notification) {
+        return new NotificationPushMessage(
+                notification.getId(),
+                notification.getUserId(),
+                notification.getCategory(),
+                notification.getTitle(),
+                notification.getMessage(),
+                notification.getPolicyId()
+        );
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/application/dto/PolicyReminderTargets.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/dto/PolicyReminderTargets.java
@@ -1,0 +1,16 @@
+package com.chungbazi.server.domain.notification.application.dto;
+
+import com.chungbazi.server.domain.policy.domain.entity.Policy;
+import java.util.List;
+
+public record PolicyReminderTargets(
+        List<Policy> deadlineInSevenDaysPolicies,
+        List<Policy> deadlineInThreeDaysPolicies
+) {
+    public static PolicyReminderTargets of(
+            List<Policy> deadlineInSevenDaysPolicies,
+            List<Policy> deadlineInThreeDaysPolicies
+    ) {
+        return new PolicyReminderTargets(deadlineInSevenDaysPolicies, deadlineInThreeDaysPolicies);
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/application/dto/PreparationReminderCreationResult.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/dto/PreparationReminderCreationResult.java
@@ -1,0 +1,13 @@
+package com.chungbazi.server.domain.notification.application.dto;
+
+public record PreparationReminderCreationResult(
+        int targetCount,
+        int createdNotificationCount
+) {
+    public static PreparationReminderCreationResult of(
+            int targetCount,
+            int createdNotificationCount
+    ) {
+        return new PreparationReminderCreationResult(targetCount, createdNotificationCount);
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/application/event/DeadlineReminderNotificationsCreatedEvent.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/event/DeadlineReminderNotificationsCreatedEvent.java
@@ -1,0 +1,14 @@
+package com.chungbazi.server.domain.notification.application.event;
+
+import com.chungbazi.server.domain.notification.application.dto.NotificationPushMessage;
+import java.util.List;
+
+public record DeadlineReminderNotificationsCreatedEvent(
+        List<NotificationPushMessage> messages
+) {
+    public static DeadlineReminderNotificationsCreatedEvent of(
+            List<NotificationPushMessage> messages
+    ) {
+        return new DeadlineReminderNotificationsCreatedEvent(List.copyOf(messages));
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/application/event/FirebaseNotificationEventListener.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/event/FirebaseNotificationEventListener.java
@@ -1,0 +1,30 @@
+package com.chungbazi.server.domain.notification.application.event;
+
+import com.chungbazi.server.domain.notification.infrastructure.fcm.FirebaseNotificationService;
+import com.chungbazi.server.global.config.AsyncConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "firebase", name = "enabled", havingValue = "true")
+public class FirebaseNotificationEventListener {
+
+    private final FirebaseNotificationService firebaseNotificationService;
+
+    @Async(AsyncConfig.NOTIFICATION_EXECUTOR)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(DeadlineReminderNotificationsCreatedEvent event) {
+        try {
+            firebaseNotificationService.sendDeadlineReminders(event);
+        } catch (RuntimeException exception) {
+            log.error("비동기 FCM 정책 리마인드 발송 중 오류 발생", exception);
+        }
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/application/event/FirebaseNotificationEventListener.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/event/FirebaseNotificationEventListener.java
@@ -20,9 +20,9 @@ public class FirebaseNotificationEventListener {
 
     @Async(AsyncConfig.NOTIFICATION_EXECUTOR)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(DeadlineReminderNotificationsCreatedEvent event) {
+    public void handle(PolicyReminderNotificationsCreatedEvent event) {
         try {
-            firebaseNotificationService.sendDeadlineReminders(event);
+            firebaseNotificationService.sendPolicyReminders(event);
         } catch (RuntimeException exception) {
             log.error("비동기 FCM 정책 리마인드 발송 중 오류 발생", exception);
         }

--- a/src/main/java/com/chungbazi/server/domain/notification/application/event/PolicyReminderNotificationsCreatedEvent.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/event/PolicyReminderNotificationsCreatedEvent.java
@@ -3,12 +3,12 @@ package com.chungbazi.server.domain.notification.application.event;
 import com.chungbazi.server.domain.notification.application.dto.NotificationPushMessage;
 import java.util.List;
 
-public record DeadlineReminderNotificationsCreatedEvent(
+public record PolicyReminderNotificationsCreatedEvent(
         List<NotificationPushMessage> messages
 ) {
-    public static DeadlineReminderNotificationsCreatedEvent of(
+    public static PolicyReminderNotificationsCreatedEvent of(
             List<NotificationPushMessage> messages
     ) {
-        return new DeadlineReminderNotificationsCreatedEvent(List.copyOf(messages));
+        return new PolicyReminderNotificationsCreatedEvent(List.copyOf(messages));
     }
 }

--- a/src/main/java/com/chungbazi/server/domain/notification/application/mapper/NotificationReminderMapper.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/mapper/NotificationReminderMapper.java
@@ -1,19 +1,23 @@
 package com.chungbazi.server.domain.notification.application.mapper;
 
-import com.chungbazi.server.domain.notification.application.dto.PolicyReminderTargets;
 import com.chungbazi.server.domain.notification.application.dto.NotificationPushMessage;
+import com.chungbazi.server.domain.notification.application.dto.PolicyReminderTargets;
 import com.chungbazi.server.domain.notification.domain.Notification;
 import com.chungbazi.server.domain.notification.domain.type.NotificationCategory;
 import com.chungbazi.server.domain.notification.domain.type.NotificationType;
 import com.chungbazi.server.domain.policy.domain.entity.PolicyLike;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Component;
 
 @Component
+// TODO:정책 제목으로 부연설명 추가
 public class NotificationReminderMapper {
 
+    private static final String PREPARATION_TITLE = "찜한 정책, 미리 준비해볼까요?";
+    private static final String PREPARATION_MESSAGE =
+            "신청할 때 놓치는 내용이 없도록 필요한 정보와 신청 방법을 미리 살펴보세요.";
     private static final String DEADLINE_D7_TITLE = "찜한 정책 신청이 일주일 남았어요!";
     private static final String DEADLINE_D7_MESSAGE =
             "여유 있게 준비할 수 있도록 신청 방법과 필요한 정보를 미리 확인해보세요.";
@@ -40,6 +44,17 @@ public class NotificationReminderMapper {
                 type,
                 deadlineInSevenDays ? DEADLINE_D7_TITLE : DEADLINE_D3_TITLE,
                 deadlineInSevenDays ? DEADLINE_D7_MESSAGE : DEADLINE_D3_MESSAGE,
+                policyLike.getPolicy().getId()
+        );
+    }
+
+    public Notification toPreparationNotification(PolicyLike policyLike) {
+        return Notification.create(
+                policyLike.getUserId(),
+                NotificationCategory.MY_POLICY,
+                NotificationType.POLICY_PREPARATION,
+                PREPARATION_TITLE,
+                PREPARATION_MESSAGE,
                 policyLike.getPolicy().getId()
         );
     }

--- a/src/main/java/com/chungbazi/server/domain/notification/application/mapper/NotificationReminderMapper.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/mapper/NotificationReminderMapper.java
@@ -12,17 +12,16 @@ import java.util.Map;
 import org.springframework.stereotype.Component;
 
 @Component
-// TODO:정책 제목으로 부연설명 추가
 public class NotificationReminderMapper {
 
     private static final String PREPARATION_TITLE = "찜한 정책, 미리 준비해볼까요?";
-    private static final String PREPARATION_MESSAGE =
+    private static final String PREPARATION_MESSAGE_BODY =
             "신청할 때 놓치는 내용이 없도록 필요한 정보와 신청 방법을 미리 살펴보세요.";
     private static final String DEADLINE_D7_TITLE = "찜한 정책 신청이 일주일 남았어요!";
-    private static final String DEADLINE_D7_MESSAGE =
+    private static final String DEADLINE_D7_MESSAGE_BODY =
             "여유 있게 준비할 수 있도록 신청 방법과 필요한 정보를 미리 확인해보세요.";
     private static final String DEADLINE_D3_TITLE = "찜한 정책 신청이 3일 남았어요!";
-    private static final String DEADLINE_D3_MESSAGE =
+    private static final String DEADLINE_D3_MESSAGE_BODY =
             "신청 기간을 놓치지 않도록 필요한 정보를 확인하고 신청을 준비해보세요.";
 
     public Map<Long, NotificationType> toReminderTypeByPolicyId(PolicyReminderTargets targets) {
@@ -43,7 +42,12 @@ public class NotificationReminderMapper {
                 NotificationCategory.MY_POLICY,
                 type,
                 deadlineInSevenDays ? DEADLINE_D7_TITLE : DEADLINE_D3_TITLE,
-                deadlineInSevenDays ? DEADLINE_D7_MESSAGE : DEADLINE_D3_MESSAGE,
+                messageWithPolicyTitle(
+                        policyLike,
+                        deadlineInSevenDays
+                                ? DEADLINE_D7_MESSAGE_BODY
+                                : DEADLINE_D3_MESSAGE_BODY
+                ),
                 policyLike.getPolicy().getId()
         );
     }
@@ -54,7 +58,7 @@ public class NotificationReminderMapper {
                 NotificationCategory.MY_POLICY,
                 NotificationType.POLICY_PREPARATION,
                 PREPARATION_TITLE,
-                PREPARATION_MESSAGE,
+                messageWithPolicyTitle(policyLike, PREPARATION_MESSAGE_BODY),
                 policyLike.getPolicy().getId()
         );
     }
@@ -63,5 +67,12 @@ public class NotificationReminderMapper {
         return notifications.stream()
                 .map(NotificationPushMessage::from)
                 .toList();
+    }
+
+    private String messageWithPolicyTitle(PolicyLike policyLike, String messageBody) {
+        return "찜한 정책 '%s': %s".formatted(
+                policyLike.getPolicy().getTitle(),
+                messageBody
+        );
     }
 }

--- a/src/main/java/com/chungbazi/server/domain/notification/application/mapper/NotificationReminderMapper.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/mapper/NotificationReminderMapper.java
@@ -1,12 +1,14 @@
 package com.chungbazi.server.domain.notification.application.mapper;
 
 import com.chungbazi.server.domain.notification.application.dto.PolicyReminderTargets;
+import com.chungbazi.server.domain.notification.application.dto.NotificationPushMessage;
 import com.chungbazi.server.domain.notification.domain.Notification;
 import com.chungbazi.server.domain.notification.domain.type.NotificationCategory;
 import com.chungbazi.server.domain.notification.domain.type.NotificationType;
 import com.chungbazi.server.domain.policy.domain.entity.PolicyLike;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -40,5 +42,11 @@ public class NotificationReminderMapper {
                 deadlineInSevenDays ? DEADLINE_D7_MESSAGE : DEADLINE_D3_MESSAGE,
                 policyLike.getPolicy().getId()
         );
+    }
+
+    public List<NotificationPushMessage> toPushMessages(List<Notification> notifications) {
+        return notifications.stream()
+                .map(NotificationPushMessage::from)
+                .toList();
     }
 }

--- a/src/main/java/com/chungbazi/server/domain/notification/application/mapper/NotificationReminderMapper.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/mapper/NotificationReminderMapper.java
@@ -1,0 +1,44 @@
+package com.chungbazi.server.domain.notification.application.mapper;
+
+import com.chungbazi.server.domain.notification.application.dto.PolicyReminderTargets;
+import com.chungbazi.server.domain.notification.domain.Notification;
+import com.chungbazi.server.domain.notification.domain.type.NotificationCategory;
+import com.chungbazi.server.domain.notification.domain.type.NotificationType;
+import com.chungbazi.server.domain.policy.domain.entity.PolicyLike;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationReminderMapper {
+
+    private static final String DEADLINE_D7_TITLE = "찜한 정책 신청이 일주일 남았어요!";
+    private static final String DEADLINE_D7_MESSAGE =
+            "여유 있게 준비할 수 있도록 신청 방법과 필요한 정보를 미리 확인해보세요.";
+    private static final String DEADLINE_D3_TITLE = "찜한 정책 신청이 3일 남았어요!";
+    private static final String DEADLINE_D3_MESSAGE =
+            "신청 기간을 놓치지 않도록 필요한 정보를 확인하고 신청을 준비해보세요.";
+
+    public Map<Long, NotificationType> toReminderTypeByPolicyId(PolicyReminderTargets targets) {
+        Map<Long, NotificationType> reminderTypeByPolicyId = new HashMap<>();
+        targets.deadlineInSevenDaysPolicies().forEach(policy ->
+                reminderTypeByPolicyId.put(policy.getId(), NotificationType.POLICY_DEADLINE_D7)
+        );
+        targets.deadlineInThreeDaysPolicies().forEach(policy ->
+                reminderTypeByPolicyId.put(policy.getId(), NotificationType.POLICY_DEADLINE_D3)
+        );
+        return reminderTypeByPolicyId;
+    }
+
+    public Notification toDeadlineNotification(PolicyLike policyLike, NotificationType type) {
+        boolean deadlineInSevenDays = type == NotificationType.POLICY_DEADLINE_D7;
+        return Notification.create(
+                policyLike.getUserId(),
+                NotificationCategory.MY_POLICY,
+                type,
+                deadlineInSevenDays ? DEADLINE_D7_TITLE : DEADLINE_D3_TITLE,
+                deadlineInSevenDays ? DEADLINE_D7_MESSAGE : DEADLINE_D3_MESSAGE,
+                policyLike.getPolicy().getId()
+        );
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/domain/Notification.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/domain/Notification.java
@@ -1,6 +1,7 @@
 package com.chungbazi.server.domain.notification.domain;
 
 import com.chungbazi.server.domain.notification.domain.type.NotificationCategory;
+import com.chungbazi.server.domain.notification.domain.type.NotificationType;
 import com.chungbazi.server.global.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -49,6 +50,10 @@ public class Notification extends BaseTimeEntity {
     @Column(name = "notification_category", nullable = false, length = 20)
     private NotificationCategory category;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "notification_type", nullable = false, length = 40)
+    private NotificationType type;
+
     @Column(name = "title", nullable = false, length = 100)
     private String title;
 
@@ -64,6 +69,7 @@ public class Notification extends BaseTimeEntity {
     public static Notification create(
             Long userId,
             NotificationCategory category,
+            NotificationType type,
             String title,
             String message,
             Long policyId
@@ -71,6 +77,7 @@ public class Notification extends BaseTimeEntity {
         Notification notification = new Notification();
         notification.userId = userId;
         notification.category = category;
+        notification.type = type;
         notification.title = title;
         notification.message = message;
         notification.policyId = policyId;

--- a/src/main/java/com/chungbazi/server/domain/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/domain/repository/NotificationRepository.java
@@ -1,16 +1,24 @@
 package com.chungbazi.server.domain.notification.domain.repository;
 
 import com.chungbazi.server.domain.notification.domain.Notification;
+import com.chungbazi.server.domain.notification.domain.type.NotificationType;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
+import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
 
     boolean existsByUserIdAndReadFalse(Long userId);
+
+    List<Notification> findAllByUserIdInAndPolicyIdInAndTypeIn(
+            Collection<Long> userIds,
+            Collection<Long> policyIds,
+            Collection<NotificationType> types
+    );
 
     @Modifying(clearAutomatically = true)
     @Query("""

--- a/src/main/java/com/chungbazi/server/domain/notification/domain/repository/NotificationSettingRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/domain/repository/NotificationSettingRepository.java
@@ -3,10 +3,27 @@ package com.chungbazi.server.domain.notification.domain.repository;
 import com.chungbazi.server.domain.notification.domain.NotificationSetting;
 import com.chungbazi.server.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
 
     Optional<NotificationSetting> findByUser(User user);
+
+    @Query("""
+            SELECT setting
+            FROM NotificationSetting setting
+            JOIN FETCH setting.user user
+            WHERE user.id IN :userIds
+              AND user.deleted = false
+              AND user.fcmToken IS NOT NULL
+              AND setting.policyNotificationEnabled = true
+            """)
+    List<NotificationSetting> findPolicyPushEnabledSettings(
+            @Param("userIds") Collection<Long> userIds
+    );
 }

--- a/src/main/java/com/chungbazi/server/domain/notification/domain/type/NotificationType.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/domain/type/NotificationType.java
@@ -1,0 +1,18 @@
+package com.chungbazi.server.domain.notification.domain.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+    POLICY_PREPARATION("찜한 정책 신청 준비"),
+    POLICY_DEADLINE_D7("찜한 정책 신청 마감 7일 전"),
+    POLICY_DEADLINE_D3("찜한 정책 신청 마감 3일 전"),
+    POLICY_UPDATED("찜한 정책 정보 변경"),
+    PERSONALIZED_POLICY("맞춤 정책 추천"),
+    INTEREST_POLICY("관심 분야 신규 정책"),
+    UNKNOWN("기존 알림");
+
+    private final String description;
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/infrastructure/fcm/FirebaseNotificationSender.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/infrastructure/fcm/FirebaseNotificationSender.java
@@ -1,0 +1,92 @@
+package com.chungbazi.server.domain.notification.infrastructure.fcm;
+
+import com.chungbazi.server.domain.notification.application.dto.NotificationPushMessage;
+import com.chungbazi.server.domain.notification.infrastructure.fcm.dto.FirebasePushResult;
+import com.chungbazi.server.domain.notification.infrastructure.fcm.dto.FirebasePushTarget;
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.SendResponse;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "firebase", name = "enabled", havingValue = "true")
+public class FirebaseNotificationSender {
+
+    private static final int FCM_BATCH_SIZE = 500;
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    public FirebasePushResult sendAll(List<FirebasePushTarget> targets) {
+        int successCount = 0;
+        int failureCount = 0;
+        Set<String> invalidFcmTokens = new HashSet<>();
+
+        for (int start = 0; start < targets.size(); start += FCM_BATCH_SIZE) {
+            List<FirebasePushTarget> batchTargets = targets.subList(
+                    start,
+                    Math.min(start + FCM_BATCH_SIZE, targets.size())
+            );
+            List<Message> messages = batchTargets.stream()
+                    .map(this::toFirebaseMessage)
+                    .toList();
+
+            try {
+                BatchResponse response = firebaseMessaging.sendEach(messages);
+                successCount += response.getSuccessCount();
+                failureCount += response.getFailureCount();
+                collectInvalidTokens(batchTargets, response.getResponses(), invalidFcmTokens);
+            } catch (FirebaseMessagingException exception) {
+                failureCount += batchTargets.size();
+                log.error("FCM 배치 발송 실패. 대상 수={}", batchTargets.size(), exception);
+            }
+        }
+
+        return FirebasePushResult.of(successCount, failureCount, invalidFcmTokens);
+    }
+
+    private Message toFirebaseMessage(FirebasePushTarget target) {
+        NotificationPushMessage message = target.message();
+        Message.Builder builder = Message.builder()
+                .setToken(target.fcmToken())
+                .setNotification(com.google.firebase.messaging.Notification.builder()
+                        .setTitle(message.title())
+                        .setBody(message.message())
+                        .build())
+                .putData("category", message.category().name())
+                .putData("policyId", String.valueOf(message.policyId()));
+
+        if (message.notificationId() != null) {
+            builder.putData("notificationId", String.valueOf(message.notificationId()));
+        }
+        return builder.build();
+    }
+
+    private void collectInvalidTokens(
+            List<FirebasePushTarget> targets,
+            List<SendResponse> responses,
+            Set<String> invalidFcmTokens
+    ) {
+        for (int index = 0; index < responses.size(); index++) {
+            SendResponse response = responses.get(index);
+            if (!response.isSuccessful() && isUnregistered(response.getException())) {
+                invalidFcmTokens.add(targets.get(index).fcmToken());
+            }
+        }
+    }
+
+    private boolean isUnregistered(FirebaseMessagingException exception) {
+        return exception != null
+                && exception.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED;
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/infrastructure/fcm/FirebaseNotificationService.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/infrastructure/fcm/FirebaseNotificationService.java
@@ -1,0 +1,67 @@
+package com.chungbazi.server.domain.notification.infrastructure.fcm;
+
+import com.chungbazi.server.domain.notification.application.dto.NotificationPushMessage;
+import com.chungbazi.server.domain.notification.application.event.DeadlineReminderNotificationsCreatedEvent;
+import com.chungbazi.server.domain.notification.domain.NotificationSetting;
+import com.chungbazi.server.domain.notification.domain.repository.NotificationSettingRepository;
+import com.chungbazi.server.domain.notification.infrastructure.fcm.dto.FirebasePushResult;
+import com.chungbazi.server.domain.notification.infrastructure.fcm.dto.FirebasePushTarget;
+import com.chungbazi.server.domain.user.infrastructure.UserRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "firebase", name = "enabled", havingValue = "true")
+public class FirebaseNotificationService {
+
+    private final NotificationSettingRepository notificationSettingRepository;
+    private final UserRepository userRepository;
+    private final FirebaseNotificationSender firebaseNotificationSender;
+
+    public void sendDeadlineReminders(DeadlineReminderNotificationsCreatedEvent event) {
+        Set<Long> userIds = event.messages().stream()
+                .map(NotificationPushMessage::userId)
+                .collect(Collectors.toSet());
+
+        List<NotificationSetting> enabledSettings =
+                notificationSettingRepository.findPolicyPushEnabledSettings(userIds);
+
+        Map<Long, String> fcmTokenByUserId = enabledSettings.stream()
+                .collect(Collectors.toMap(
+                        setting -> setting.getUser().getId(),
+                        setting -> setting.getUser().getFcmToken()
+                ));
+
+        List<FirebasePushTarget> targets = event.messages().stream()
+                .filter(message -> fcmTokenByUserId.containsKey(message.userId()))
+                .map(message -> FirebasePushTarget.of(
+                        fcmTokenByUserId.get(message.userId()),
+                        message
+                ))
+                .toList();
+
+        if (targets.isEmpty()) {
+            return;
+        }
+
+        FirebasePushResult result = firebaseNotificationSender.sendAll(targets);
+        if (!result.invalidFcmTokens().isEmpty()) {
+            userRepository.clearInvalidFcmTokens(result.invalidFcmTokens());
+        }
+
+        log.info(
+                "FCM 정책 리마인드 발송 완료. 성공={}, 실패={}, 무효 토큰={}",
+                result.successCount(),
+                result.failureCount(),
+                result.invalidFcmTokens().size()
+        );
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/infrastructure/fcm/FirebaseNotificationService.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/infrastructure/fcm/FirebaseNotificationService.java
@@ -1,7 +1,7 @@
 package com.chungbazi.server.domain.notification.infrastructure.fcm;
 
 import com.chungbazi.server.domain.notification.application.dto.NotificationPushMessage;
-import com.chungbazi.server.domain.notification.application.event.DeadlineReminderNotificationsCreatedEvent;
+import com.chungbazi.server.domain.notification.application.event.PolicyReminderNotificationsCreatedEvent;
 import com.chungbazi.server.domain.notification.domain.NotificationSetting;
 import com.chungbazi.server.domain.notification.domain.repository.NotificationSettingRepository;
 import com.chungbazi.server.domain.notification.infrastructure.fcm.dto.FirebasePushResult;
@@ -26,7 +26,7 @@ public class FirebaseNotificationService {
     private final UserRepository userRepository;
     private final FirebaseNotificationSender firebaseNotificationSender;
 
-    public void sendDeadlineReminders(DeadlineReminderNotificationsCreatedEvent event) {
+    public void sendPolicyReminders(PolicyReminderNotificationsCreatedEvent event) {
         Set<Long> userIds = event.messages().stream()
                 .map(NotificationPushMessage::userId)
                 .collect(Collectors.toSet());

--- a/src/main/java/com/chungbazi/server/domain/notification/infrastructure/fcm/dto/FirebasePushResult.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/infrastructure/fcm/dto/FirebasePushResult.java
@@ -1,0 +1,17 @@
+package com.chungbazi.server.domain.notification.infrastructure.fcm.dto;
+
+import java.util.Set;
+
+public record FirebasePushResult(
+        int successCount,
+        int failureCount,
+        Set<String> invalidFcmTokens
+) {
+    public static FirebasePushResult of(
+            int successCount,
+            int failureCount,
+            Set<String> invalidFcmTokens
+    ) {
+        return new FirebasePushResult(successCount, failureCount, Set.copyOf(invalidFcmTokens));
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/infrastructure/fcm/dto/FirebasePushTarget.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/infrastructure/fcm/dto/FirebasePushTarget.java
@@ -1,0 +1,15 @@
+package com.chungbazi.server.domain.notification.infrastructure.fcm.dto;
+
+import com.chungbazi.server.domain.notification.application.dto.NotificationPushMessage;
+
+public record FirebasePushTarget(
+        String fcmToken,
+        NotificationPushMessage message
+) {
+    public static FirebasePushTarget of(
+            String fcmToken,
+            NotificationPushMessage message
+    ) {
+        return new FirebasePushTarget(fcmToken, message);
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/infrastructure/scheduler/NotificationReminderScheduler.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/infrastructure/scheduler/NotificationReminderScheduler.java
@@ -1,0 +1,42 @@
+package com.chungbazi.server.domain.notification.infrastructure.scheduler;
+
+import com.chungbazi.server.domain.notification.application.NotificationReminderService;
+import com.chungbazi.server.domain.notification.application.dto.DeadlineReminderCreationResult;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationReminderScheduler {
+
+    private static final ZoneId SERVICE_ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    private final NotificationReminderService notificationReminderService;
+
+    @Scheduled(
+            cron = "${notification.reminder.cron:0 0 9 * * *}",
+            zone = "Asia/Seoul"
+    )
+    public void sendPolicyReminderNotifications() {
+        log.info("정책 리마인드 알림 스케줄러 실행");
+
+        DeadlineReminderCreationResult result =
+                notificationReminderService.createDeadlineReminderNotifications(
+                LocalDate.now(SERVICE_ZONE_ID)
+        );
+
+        log.info(
+                "정책 리마인드 알림 생성 완료. 마감 7일 전 정책 수={}, 마감 3일 전 정책 수={}, 생성 알림 수={}",
+                result.deadlineInSevenDaysPolicyCount(),
+                result.deadlineInThreeDaysPolicyCount(),
+                result.createdNotificationCount()
+        );
+
+        // TODO: 생성된 알림의 FCM 발송 로직 구현
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/infrastructure/scheduler/NotificationReminderScheduler.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/infrastructure/scheduler/NotificationReminderScheduler.java
@@ -37,6 +37,5 @@ public class NotificationReminderScheduler {
                 result.createdNotificationCount()
         );
 
-        // TODO: 생성된 알림의 FCM 발송 로직 구현
     }
 }

--- a/src/main/java/com/chungbazi/server/domain/notification/infrastructure/scheduler/NotificationReminderScheduler.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/infrastructure/scheduler/NotificationReminderScheduler.java
@@ -2,7 +2,9 @@ package com.chungbazi.server.domain.notification.infrastructure.scheduler;
 
 import com.chungbazi.server.domain.notification.application.NotificationReminderService;
 import com.chungbazi.server.domain.notification.application.dto.DeadlineReminderCreationResult;
+import com.chungbazi.server.domain.notification.application.dto.PreparationReminderCreationResult;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,8 +29,8 @@ public class NotificationReminderScheduler {
 
         DeadlineReminderCreationResult result =
                 notificationReminderService.createDeadlineReminderNotifications(
-                LocalDate.now(SERVICE_ZONE_ID)
-        );
+                        LocalDate.now(SERVICE_ZONE_ID)
+                );
 
         log.info(
                 "정책 리마인드 알림 생성 완료. 마감 7일 전 정책 수={}, 마감 3일 전 정책 수={}, 생성 알림 수={}",
@@ -37,5 +39,24 @@ public class NotificationReminderScheduler {
                 result.createdNotificationCount()
         );
 
+    }
+
+    @Scheduled(
+            cron = "${notification.reminder.preparation-cron:0 0 * * * *}",
+            zone = "Asia/Seoul"
+    )
+    public void sendPolicyPreparationNotifications() {
+        log.info("찜한 정책 신청 준비 알림 스케줄러 실행");
+
+        PreparationReminderCreationResult result =
+                notificationReminderService.createPreparationReminderNotifications(
+                        LocalDateTime.now(SERVICE_ZONE_ID)
+                );
+
+        log.info(
+                "찜한 정책 신청 준비 알림 생성 완료. 대상 수={}, 생성 알림 수={}",
+                result.targetCount(),
+                result.createdNotificationCount()
+        );
     }
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
@@ -45,6 +45,18 @@ public interface PolicyLikeRepository extends JpaRepository<PolicyLike, Long> {
     @Query("""
             SELECT policyLike
             FROM PolicyLike policyLike
+            JOIN FETCH policyLike.policy policy
+            JOIN User user ON user.id = policyLike.userId
+            WHERE policy.id IN :policyIds
+              AND user.deleted = false
+            """)
+    List<PolicyLike> findDeadlineReminderRecipients(
+            @Param("policyIds") Collection<Long> policyIds
+    );
+
+    @Query("""
+            SELECT policyLike
+            FROM PolicyLike policyLike
             JOIN FETCH policyLike.policy
             WHERE policyLike.userId = :userId
               AND policyLike.policy.id = :policyId

--- a/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyLikeRepository.java
@@ -57,6 +57,22 @@ public interface PolicyLikeRepository extends JpaRepository<PolicyLike, Long> {
     @Query("""
             SELECT policyLike
             FROM PolicyLike policyLike
+            JOIN FETCH policyLike.policy policy
+            JOIN User user ON user.id = policyLike.userId
+            WHERE policyLike.createdAt >= :likedFrom
+              AND policyLike.createdAt < :likedUntil
+              AND policy.recruitmentStatus <> :closedStatus
+              AND user.deleted = false
+            """)
+    List<PolicyLike> findPreparationReminderTargets(
+            @Param("likedFrom") LocalDateTime likedFrom,
+            @Param("likedUntil") LocalDateTime likedUntil,
+            @Param("closedStatus") RecruitmentStatus closedStatus
+    );
+
+    @Query("""
+            SELECT policyLike
+            FROM PolicyLike policyLike
             JOIN FETCH policyLike.policy
             WHERE policyLike.userId = :userId
               AND policyLike.policy.id = :policyId

--- a/src/main/java/com/chungbazi/server/domain/policy/domain/repository/policyRepository/PolicyRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/domain/repository/policyRepository/PolicyRepository.java
@@ -1,6 +1,10 @@
 package com.chungbazi.server.domain.policy.domain.repository.policyRepository;
 
 import com.chungbazi.server.domain.policy.domain.entity.Policy;
+import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -11,6 +15,11 @@ public interface PolicyRepository extends JpaRepository<Policy, Long>, PolicyRep
     Optional<Policy> findByPlcyNo(String plcyNo);
 
     boolean existsByPlcyNo(String plcyNo);
+
+    List<Policy> findAllByApplyEndDateInAndRecruitmentStatusNot(
+            Collection<LocalDate> applyEndDates,
+            RecruitmentStatus recruitmentStatus
+    );
 
     @Modifying
     @Query("""

--- a/src/main/java/com/chungbazi/server/domain/user/domain/User.java
+++ b/src/main/java/com/chungbazi/server/domain/user/domain/User.java
@@ -109,6 +109,10 @@ public class User extends BaseTimeEntity {
         this.fcmToken = fcmToken;
     }
 
+    public void clearFcmToken() {
+        this.fcmToken = null;
+    }
+
     public void updateName(String name) {
         this.name = name;
         this.nicknameChanged = true;

--- a/src/main/java/com/chungbazi/server/domain/user/domain/User.java
+++ b/src/main/java/com/chungbazi/server/domain/user/domain/User.java
@@ -19,10 +19,16 @@ import java.time.format.DateTimeParseException;
 @Getter
 @Table(
         name = "user",
-        uniqueConstraints = @UniqueConstraint(
-                name = "uk_user_social_provider",
-                columnNames = {"social_type", "provider_id"}
-        )
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_user_social_provider",
+                        columnNames = {"social_type", "provider_id"}
+                ),
+                @UniqueConstraint(
+                        name = "uk_user_fcm_token",
+                        columnNames = "fcm_token"
+                )
+        }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseTimeEntity {

--- a/src/main/java/com/chungbazi/server/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/user/infrastructure/UserRepository.java
@@ -3,9 +3,24 @@ package com.chungbazi.server.domain.user.infrastructure;
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.domain.user.domain.type.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findBySocialTypeAndProviderId(SocialType socialType, String providerId);
+
+    @Modifying(flushAutomatically = true)
+    @Query("""
+            update User user
+            set user.fcmToken = null
+            where user.fcmToken = :fcmToken
+              and user.id <> :currentUserId
+            """)
+    int clearFcmTokenFromOtherUsers(
+            @Param("fcmToken") String fcmToken,
+            @Param("currentUserId") Long currentUserId
+    );
 }

--- a/src/main/java/com/chungbazi/server/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/user/infrastructure/UserRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -23,4 +25,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
             @Param("fcmToken") String fcmToken,
             @Param("currentUserId") Long currentUserId
     );
+
+    @Transactional
+    @Modifying
+    @Query("""
+            update User user
+            set user.fcmToken = null
+            where user.fcmToken in :fcmTokens
+            """)
+    int clearInvalidFcmTokens(@Param("fcmTokens") Collection<String> fcmTokens);
 }

--- a/src/main/java/com/chungbazi/server/global/config/AsyncConfig.java
+++ b/src/main/java/com/chungbazi/server/global/config/AsyncConfig.java
@@ -1,6 +1,7 @@
 package com.chungbazi.server.global.config;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -16,9 +17,10 @@ public class AsyncConfig {
     public Executor notificationExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(1);
-        executor.setMaxPoolSize(2);
-        executor.setQueueCapacity(250);
+        executor.setMaxPoolSize(1);
+        executor.setQueueCapacity(10);
         executor.setThreadNamePrefix("notification-async-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(30);
         executor.initialize();

--- a/src/main/java/com/chungbazi/server/global/config/AsyncConfig.java
+++ b/src/main/java/com/chungbazi/server/global/config/AsyncConfig.java
@@ -1,0 +1,27 @@
+package com.chungbazi.server.global.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    public static final String NOTIFICATION_EXECUTOR = "notificationExecutor";
+
+    @Bean(name = NOTIFICATION_EXECUTOR)
+    public Executor notificationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(250);
+        executor.setThreadNamePrefix("notification-async-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/chungbazi/server/global/config/FirebaseConfig.java
+++ b/src/main/java/com/chungbazi/server/global/config/FirebaseConfig.java
@@ -3,6 +3,7 @@ package com.chungbazi.server.global.config;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -40,6 +41,12 @@ public class FirebaseConfig {
 
             return FirebaseApp.initializeApp(options);
         }
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "firebase", name = "enabled", havingValue = "true")
+    public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+        return FirebaseMessaging.getInstance(firebaseApp);
     }
 
     private InputStream openServiceAccount(String location) throws IOException {

--- a/src/test/java/com/chungbazi/server/domain/notification/application/NotificationReminderServiceTest.java
+++ b/src/test/java/com/chungbazi/server/domain/notification/application/NotificationReminderServiceTest.java
@@ -1,0 +1,188 @@
+package com.chungbazi.server.domain.notification.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.chungbazi.server.domain.notification.application.dto.NotificationPushMessage;
+import com.chungbazi.server.domain.notification.application.dto.PreparationReminderCreationResult;
+import com.chungbazi.server.domain.notification.application.event.PolicyReminderNotificationsCreatedEvent;
+import com.chungbazi.server.domain.notification.application.mapper.NotificationReminderMapper;
+import com.chungbazi.server.domain.notification.domain.Notification;
+import com.chungbazi.server.domain.notification.domain.repository.NotificationRepository;
+import com.chungbazi.server.domain.notification.domain.type.NotificationCategory;
+import com.chungbazi.server.domain.notification.domain.type.NotificationType;
+import com.chungbazi.server.domain.policy.domain.entity.Policy;
+import com.chungbazi.server.domain.policy.domain.entity.PolicyLike;
+import com.chungbazi.server.domain.policy.domain.repository.PolicyLikeRepository;
+import com.chungbazi.server.domain.policy.domain.repository.policyRepository.PolicyRepository;
+import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationReminderServiceTest {
+
+    @Mock
+    private PolicyRepository policyRepository;
+
+    @Mock
+    private PolicyLikeRepository policyLikeRepository;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private NotificationReminderMapper notificationReminderMapper;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private NotificationReminderService notificationReminderService;
+
+    @Test
+    void findsLikesInTheHourlyWindowAfterTwentyFourHoursAndExcludesNearDeadlines() {
+        LocalDateTime executionTime = LocalDateTime.of(2026, 8, 21, 10, 37);
+        LocalDateTime likedFrom = LocalDateTime.of(2026, 8, 20, 9, 0);
+        LocalDateTime likedUntil = LocalDateTime.of(2026, 8, 20, 10, 0);
+
+        PolicyLike eligibleLike = policyLike(
+                LocalDateTime.of(2026, 8, 20, 9, 30),
+                LocalDate.of(2026, 8, 28)
+        );
+        PolicyLike openEndedLike = policyLike(
+                LocalDateTime.of(2026, 8, 20, 9, 40),
+                null
+        );
+        PolicyLike deadlineInSevenDaysLike = policyLike(
+                LocalDateTime.of(2026, 8, 20, 9, 50),
+                LocalDate.of(2026, 8, 27)
+        );
+
+        given(policyLikeRepository.findPreparationReminderTargets(
+                likedFrom,
+                likedUntil,
+                RecruitmentStatus.CLOSED
+        )).willReturn(List.of(
+                eligibleLike,
+                openEndedLike,
+                deadlineInSevenDaysLike
+        ));
+
+        List<PolicyLike> result =
+                notificationReminderService.findPreparationReminderTargets(executionTime);
+
+        assertThat(result).containsExactly(eligibleLike, openEndedLike);
+        verify(policyLikeRepository).findPreparationReminderTargets(
+                likedFrom,
+                likedUntil,
+                RecruitmentStatus.CLOSED
+        );
+    }
+
+    @Test
+    void savesOnlyNewPreparationNotificationsAndPublishesTheirPushEvent() {
+        LocalDateTime executionTime = LocalDateTime.of(2026, 8, 21, 10, 37);
+        LocalDateTime likedFrom = LocalDateTime.of(2026, 8, 20, 9, 0);
+        LocalDateTime likedUntil = LocalDateTime.of(2026, 8, 20, 10, 0);
+        PolicyLike newTarget = preparationTarget(1L, 10L);
+        PolicyLike duplicateTarget = preparationTarget(2L, 20L);
+
+        Notification newNotification = preparationNotification(1L, 10L);
+        Notification duplicateNotification = preparationNotification(2L, 20L);
+        Notification existingNotification = preparationNotification(2L, 20L);
+        List<NotificationPushMessage> pushMessages = List.of(
+                NotificationPushMessage.from(newNotification)
+        );
+
+        given(policyLikeRepository.findPreparationReminderTargets(
+                likedFrom,
+                likedUntil,
+                RecruitmentStatus.CLOSED
+        )).willReturn(List.of(newTarget, duplicateTarget));
+        given(notificationRepository.findAllByUserIdInAndPolicyIdInAndTypeIn(
+                Set.of(1L, 2L),
+                Set.of(10L, 20L),
+                Set.of(NotificationType.POLICY_PREPARATION)
+        )).willReturn(List.of(existingNotification));
+        given(notificationReminderMapper.toPreparationNotification(newTarget))
+                .willReturn(newNotification);
+        given(notificationReminderMapper.toPreparationNotification(duplicateTarget))
+                .willReturn(duplicateNotification);
+        given(notificationReminderMapper.toPushMessages(List.of(newNotification)))
+                .willReturn(pushMessages);
+
+        PreparationReminderCreationResult result =
+                notificationReminderService.createPreparationReminderNotifications(executionTime);
+
+        assertThat(result.targetCount()).isEqualTo(2);
+        assertThat(result.createdNotificationCount()).isEqualTo(1);
+        verify(notificationRepository).saveAll(List.of(newNotification));
+
+        ArgumentCaptor<PolicyReminderNotificationsCreatedEvent> eventCaptor =
+                ArgumentCaptor.forClass(PolicyReminderNotificationsCreatedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().messages()).containsExactlyElementsOf(pushMessages);
+    }
+
+    @Test
+    void doesNotSaveOrPublishWhenThereAreNoPreparationTargets() {
+        LocalDateTime executionTime = LocalDateTime.of(2026, 8, 21, 10, 0);
+        given(policyLikeRepository.findPreparationReminderTargets(
+                LocalDateTime.of(2026, 8, 20, 9, 0),
+                LocalDateTime.of(2026, 8, 20, 10, 0),
+                RecruitmentStatus.CLOSED
+        )).willReturn(List.of());
+
+        PreparationReminderCreationResult result =
+                notificationReminderService.createPreparationReminderNotifications(executionTime);
+
+        assertThat(result.targetCount()).isZero();
+        assertThat(result.createdNotificationCount()).isZero();
+        verifyNoInteractions(notificationRepository, notificationReminderMapper, eventPublisher);
+    }
+
+    private PolicyLike policyLike(LocalDateTime likedAt, LocalDate applyEndDate) {
+        Policy policy = org.mockito.Mockito.mock(Policy.class);
+        PolicyLike policyLike = org.mockito.Mockito.mock(PolicyLike.class);
+
+        given(policy.getApplyEndDate()).willReturn(applyEndDate);
+        given(policyLike.getPolicy()).willReturn(policy);
+        if (applyEndDate != null) {
+            given(policyLike.getCreatedAt()).willReturn(likedAt);
+        }
+        return policyLike;
+    }
+
+    private PolicyLike preparationTarget(Long userId, Long policyId) {
+        Policy policy = org.mockito.Mockito.mock(Policy.class);
+        PolicyLike policyLike = org.mockito.Mockito.mock(PolicyLike.class);
+
+        given(policy.getId()).willReturn(policyId);
+        given(policyLike.getUserId()).willReturn(userId);
+        given(policyLike.getPolicy()).willReturn(policy);
+        return policyLike;
+    }
+
+    private Notification preparationNotification(Long userId, Long policyId) {
+        return Notification.create(
+                userId,
+                NotificationCategory.MY_POLICY,
+                NotificationType.POLICY_PREPARATION,
+                "찜한 정책, 미리 준비해볼까요?",
+                "신청할 때 놓치는 내용이 없도록 필요한 정보와 신청 방법을 미리 살펴보세요.",
+                policyId
+        );
+    }
+}

--- a/src/test/java/com/chungbazi/server/domain/notification/application/mapper/NotificationReminderMapperTest.java
+++ b/src/test/java/com/chungbazi/server/domain/notification/application/mapper/NotificationReminderMapperTest.java
@@ -1,0 +1,39 @@
+package com.chungbazi.server.domain.notification.application.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.chungbazi.server.domain.notification.domain.Notification;
+import com.chungbazi.server.domain.notification.domain.type.NotificationCategory;
+import com.chungbazi.server.domain.notification.domain.type.NotificationType;
+import com.chungbazi.server.domain.policy.domain.entity.Policy;
+import com.chungbazi.server.domain.policy.domain.entity.PolicyLike;
+import org.junit.jupiter.api.Test;
+
+class NotificationReminderMapperTest {
+
+    private final NotificationReminderMapper notificationReminderMapper =
+            new NotificationReminderMapper();
+
+    @Test
+    void mapsPreparationNotificationWithTheSpecifiedContent() {
+        Policy policy = org.mockito.Mockito.mock(Policy.class);
+        PolicyLike policyLike = org.mockito.Mockito.mock(PolicyLike.class);
+        given(policy.getId()).willReturn(10L);
+        given(policyLike.getUserId()).willReturn(1L);
+        given(policyLike.getPolicy()).willReturn(policy);
+
+        Notification notification =
+                notificationReminderMapper.toPreparationNotification(policyLike);
+
+        assertThat(notification.getUserId()).isEqualTo(1L);
+        assertThat(notification.getPolicyId()).isEqualTo(10L);
+        assertThat(notification.getCategory()).isEqualTo(NotificationCategory.MY_POLICY);
+        assertThat(notification.getType()).isEqualTo(NotificationType.POLICY_PREPARATION);
+        assertThat(notification.getTitle()).isEqualTo("찜한 정책, 미리 준비해볼까요?");
+        assertThat(notification.getMessage()).isEqualTo(
+                "신청할 때 놓치는 내용이 없도록 필요한 정보와 신청 방법을 미리 살펴보세요."
+        );
+        assertThat(notification.isRead()).isFalse();
+    }
+}

--- a/src/test/java/com/chungbazi/server/domain/notification/application/mapper/NotificationReminderMapperTest.java
+++ b/src/test/java/com/chungbazi/server/domain/notification/application/mapper/NotificationReminderMapperTest.java
@@ -20,6 +20,7 @@ class NotificationReminderMapperTest {
         Policy policy = org.mockito.Mockito.mock(Policy.class);
         PolicyLike policyLike = org.mockito.Mockito.mock(PolicyLike.class);
         given(policy.getId()).willReturn(10L);
+        given(policy.getTitle()).willReturn("청년 취업 지원 정책");
         given(policyLike.getUserId()).willReturn(1L);
         given(policyLike.getPolicy()).willReturn(policy);
 
@@ -32,8 +33,37 @@ class NotificationReminderMapperTest {
         assertThat(notification.getType()).isEqualTo(NotificationType.POLICY_PREPARATION);
         assertThat(notification.getTitle()).isEqualTo("찜한 정책, 미리 준비해볼까요?");
         assertThat(notification.getMessage()).isEqualTo(
-                "신청할 때 놓치는 내용이 없도록 필요한 정보와 신청 방법을 미리 살펴보세요."
+                "찜한 정책 '청년 취업 지원 정책': "
+                        + "신청할 때 놓치는 내용이 없도록 필요한 정보와 신청 방법을 미리 살펴보세요."
         );
         assertThat(notification.isRead()).isFalse();
+    }
+
+    @Test
+    void includesPolicyTitleInDeadlineNotificationMessages() {
+        Policy policy = org.mockito.Mockito.mock(Policy.class);
+        PolicyLike policyLike = org.mockito.Mockito.mock(PolicyLike.class);
+        given(policy.getId()).willReturn(10L);
+        given(policy.getTitle()).willReturn("청년 취업 지원 정책");
+        given(policyLike.getUserId()).willReturn(1L);
+        given(policyLike.getPolicy()).willReturn(policy);
+
+        Notification sevenDaysNotification = notificationReminderMapper.toDeadlineNotification(
+                policyLike,
+                NotificationType.POLICY_DEADLINE_D7
+        );
+        Notification threeDaysNotification = notificationReminderMapper.toDeadlineNotification(
+                policyLike,
+                NotificationType.POLICY_DEADLINE_D3
+        );
+
+        assertThat(sevenDaysNotification.getMessage()).isEqualTo(
+                "찜한 정책 '청년 취업 지원 정책': "
+                        + "여유 있게 준비할 수 있도록 신청 방법과 필요한 정보를 미리 확인해보세요."
+        );
+        assertThat(threeDaysNotification.getMessage()).isEqualTo(
+                "찜한 정책 '청년 취업 지원 정책': "
+                        + "신청 기간을 놓치지 않도록 필요한 정보를 확인하고 신청을 준비해보세요."
+        );
     }
 }

--- a/src/test/java/com/chungbazi/server/domain/notification/infrastructure/fcm/FirebaseNotificationServiceTest.java
+++ b/src/test/java/com/chungbazi/server/domain/notification/infrastructure/fcm/FirebaseNotificationServiceTest.java
@@ -1,0 +1,94 @@
+package com.chungbazi.server.domain.notification.infrastructure.fcm;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.chungbazi.server.domain.notification.application.dto.NotificationPushMessage;
+import com.chungbazi.server.domain.notification.application.event.PolicyReminderNotificationsCreatedEvent;
+import com.chungbazi.server.domain.notification.domain.NotificationSetting;
+import com.chungbazi.server.domain.notification.domain.repository.NotificationSettingRepository;
+import com.chungbazi.server.domain.notification.domain.type.NotificationCategory;
+import com.chungbazi.server.domain.notification.infrastructure.fcm.dto.FirebasePushResult;
+import com.chungbazi.server.domain.notification.infrastructure.fcm.dto.FirebasePushTarget;
+import com.chungbazi.server.domain.user.domain.User;
+import com.chungbazi.server.domain.user.infrastructure.UserRepository;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FirebaseNotificationServiceTest {
+
+    @Mock
+    private NotificationSettingRepository notificationSettingRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private FirebaseNotificationSender firebaseNotificationSender;
+
+    @InjectMocks
+    private FirebaseNotificationService firebaseNotificationService;
+
+    @Test
+    void sendsOnlyToPushEnabledUsersAndClearsInvalidTokens() {
+        NotificationPushMessage enabledUserMessage = pushMessage(1L, 10L);
+        NotificationPushMessage disabledUserMessage = pushMessage(2L, 20L);
+        PolicyReminderNotificationsCreatedEvent event =
+                PolicyReminderNotificationsCreatedEvent.of(List.of(
+                        enabledUserMessage,
+                        disabledUserMessage
+                ));
+
+        User enabledUser = org.mockito.Mockito.mock(User.class);
+        NotificationSetting enabledSetting = org.mockito.Mockito.mock(NotificationSetting.class);
+        given(enabledSetting.getUser()).willReturn(enabledUser);
+        given(enabledUser.getId()).willReturn(1L);
+        given(enabledUser.getFcmToken()).willReturn("invalid-token");
+        given(notificationSettingRepository.findPolicyPushEnabledSettings(Set.of(1L, 2L)))
+                .willReturn(List.of(enabledSetting));
+
+        FirebasePushTarget enabledTarget = FirebasePushTarget.of(
+                "invalid-token",
+                enabledUserMessage
+        );
+        given(firebaseNotificationSender.sendAll(List.of(enabledTarget)))
+                .willReturn(FirebasePushResult.of(0, 1, Set.of("invalid-token")));
+
+        firebaseNotificationService.sendPolicyReminders(event);
+
+        verify(firebaseNotificationSender).sendAll(List.of(enabledTarget));
+        verify(userRepository).clearInvalidFcmTokens(Set.of("invalid-token"));
+    }
+
+    @Test
+    void doesNotCallFirebaseWhenNoUserHasPushEnabled() {
+        NotificationPushMessage message = pushMessage(1L, 10L);
+        PolicyReminderNotificationsCreatedEvent event =
+                PolicyReminderNotificationsCreatedEvent.of(List.of(message));
+        given(notificationSettingRepository.findPolicyPushEnabledSettings(Set.of(1L)))
+                .willReturn(List.of());
+
+        firebaseNotificationService.sendPolicyReminders(event);
+
+        verify(firebaseNotificationSender, never()).sendAll(org.mockito.ArgumentMatchers.anyList());
+        verify(userRepository, never()).clearInvalidFcmTokens(org.mockito.ArgumentMatchers.anySet());
+    }
+
+    private NotificationPushMessage pushMessage(Long userId, Long policyId) {
+        return new NotificationPushMessage(
+                null,
+                userId,
+                NotificationCategory.MY_POLICY,
+                "찜한 정책, 미리 준비해볼까요?",
+                "신청할 때 놓치는 내용이 없도록 필요한 정보와 신청 방법을 미리 살펴보세요.",
+                policyId
+        );
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
- #49 

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
### FCM 토큰
- 로그인 시 FCM 토큰을 저장하고, 동일한 토큰을 사용하는 다른 사용자의 토큰을 제거했습니다.
- 로그아웃 시 인증된 사용자의 FCM 토큰을 삭제하도록 구현했습니다.
- FCM을 최대 500건 단위로 배치 발송하고, 만료·등록 해제된 FCM 토큰을 삭제하도록 처리했습니다.

### 알림
- 알림을 더 자세히 구분하기 위한 `NotificationType`을 추가했습니다. (마이그레이션 SQL 추가)
- 찜한 정책의 신청 마감 7일 전·3일 전 리마인드 알림을 구현했습니다.
- 정책을 찜한 지 24시간이 지난 사용자에게 신청 준비 알림을 생성하도록 구현했습니다.
    (신청 마감까지 7일 이하인 정책은 신청 준비 알림 대상에서 제외)
- 사용자·정책·알림 유형을 기준으로 동일 알림이 중복 생성되지 않도록 처리했습니다.
- 알림 설정과 관계없이 알림 내역은 저장하고, 내 정책 알림이 활성화된 사용자에게만 FCM을 발송하도록 구현했습니다.
- 알림 저장 트랜잭션 커밋 이후 FCM이 비동기로 발송되도록 이벤트 기반으로 분리했습니다.

## 📸 스크린샷
>

## ✅ 체크리스트
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 테스트 시 사용한 로그를 삭제했습니다.

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 알림 저장 트랜잭션 커밋 이후 비동기 FCM 이벤트가 실행되는 구조가 적절한지 확인 부탁드립니다.
- 리마인드 대상과 기존 알림을 일괄 조회하여 중복을 제거하는 방식이 적절한지 확인 부탁드립니다.
- 신청 준비 알림은 매시간 실행되며, 실행 시점 기준 24~25시간 전에 생성된 찜을 조회합니다.
- 현재 신청 준비 알림의 마감일 조건은 별도 스냅샷 없이 정책의 현재 `applyEndDate`를 기준으로 판단합니다.

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

> - **P1:** 꼭 반영해주세요 (Comment)
> - **P2:** 적극적으로 고려해주세요 (Comment)
> - **P3:** 웬만하면 반영해 주세요 (Comment)
> - **P4:** 반영해도 좋고 넘어가도 좋습니다 (Approve)
> - **P5:** 그냥 사소한 의견입니다 (Approve)

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 정책 마감 7일 전·3일 전 및 신청 준비 알림을 자동으로 제공합니다.
  * 알림 유형을 구분하고 중복 알림 생성을 방지합니다.
  * 푸시 알림을 일괄 발송하며 유효하지 않은 기기 토큰을 정리합니다.
* **개선**
  * 카카오·애플 로그인 시 FCM 토큰 입력값을 검증합니다.
  * 로그아웃하면 해당 기기의 푸시 알림 토큰이 삭제됩니다.
  * 동일한 기기 토큰이 여러 계정에 등록되지 않도록 처리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->