### PR TITLE
[Feat] 신규 맞춤 정책 추천 알림 구현

### DIFF
--- a/src/main/java/com/chungbazi/server/domain/notification/application/PersonalizedPolicyNotificationService.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/PersonalizedPolicyNotificationService.java
@@ -1,0 +1,180 @@
+package com.chungbazi.server.domain.notification.application;
+
+import com.chungbazi.server.domain.notification.application.dto.PersonalizedPolicyNotificationTarget;
+import com.chungbazi.server.domain.notification.application.mapper.PersonalizedPolicyContextMapper;
+import com.chungbazi.server.domain.policy.application.dto.PolicyRecommendationContext;
+import com.chungbazi.server.domain.policy.application.event.NewPoliciesRegisteredEvent;
+import com.chungbazi.server.domain.policy.application.support.PersonalizedPolicyRanker;
+import com.chungbazi.server.domain.policy.domain.entity.Policy;
+import com.chungbazi.server.domain.policy.domain.entity.PolicyRegion;
+import com.chungbazi.server.domain.policy.domain.repository.PolicyRegionRepository;
+import com.chungbazi.server.domain.policy.domain.repository.policyRepository.PolicyRepository;
+import com.chungbazi.server.domain.policy.domain.type.RecruitmentStatus;
+import com.chungbazi.server.domain.user.domain.User;
+import com.chungbazi.server.domain.user.domain.UserInterest;
+import com.chungbazi.server.domain.user.infrastructure.UserInterestRepository;
+import com.chungbazi.server.domain.user.infrastructure.UserRepository;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PersonalizedPolicyNotificationService {
+
+    private static final int USER_CHUNK_SIZE = 1_000;
+    private static final int PERSONALIZED_POLICY_SIZE = 5;
+    private static final long INITIAL_USER_CURSOR = 0L;
+
+    private final UserRepository userRepository;
+    private final UserInterestRepository userInterestRepository;
+    private final PolicyRepository policyRepository;
+    private final PolicyRegionRepository policyRegionRepository;
+    private final PersonalizedPolicyContextMapper personalizedPolicyContextMapper;
+    private final PersonalizedPolicyRanker personalizedPolicyRanker;
+
+    public void createPersonalizedPolicyNotifications(NewPoliciesRegisteredEvent event) {
+        List<Policy> newPolicies = policyRepository.findAllByIdInAndRecruitmentStatusNot(
+                event.policyIds(),
+                RecruitmentStatus.CLOSED
+        );
+        if (newPolicies.isEmpty()) {
+            return;
+        }
+        Map<Long, List<PolicyRegion>> policyRegionsByPolicyId = findPolicyRegionsByPolicyId(
+                newPolicies.stream().map(Policy::getId).toList()
+        );
+
+        long cursor = INITIAL_USER_CURSOR;
+        int chunkNumber = 0;
+
+        //사용자 배치 조회
+        while (true) {
+            List<User> users = userRepository.findNotificationTargetUsersAfterId(
+                    cursor,
+                    PageRequest.of(0, USER_CHUNK_SIZE)
+            );
+            if (users.isEmpty()) {
+                return;
+            }
+
+            chunkNumber++;
+            log.info(
+                    "신규 맞춤 정책 알림 사용자 청크 조회 완료. policyCount={}, chunk={}, userCount={}",
+                    event.policyIds().size(),
+                    chunkNumber,
+                    users.size()
+            );
+
+            Map<Long, PolicyRecommendationContext> contexts = findRecommendationContexts(users);
+
+            //신규 맞춤 정책 알림 대상자 선별
+            List<PersonalizedPolicyNotificationTarget> targets = findPersonalizedTargets(
+                    users,
+                    contexts,
+                    newPolicies,
+                    policyRegionsByPolicyId
+            );
+
+            log.info(
+                    "신규 맞춤 정책 알림 대상 선별 완료. chunk={}, contextCount={}, targetUserCount={}",
+                    chunkNumber,
+                    contexts.size(),
+                    targets.size()
+            );
+
+            // TODO: 선별된 신규 맞춤 정책 알림 저장
+            cursor = users.getLast().getId();
+        }
+    }
+
+    public Map<Long, PolicyRecommendationContext> findRecommendationContexts(List<User> users) {
+        Set<Long> userIds = users.stream()
+                .map(User::getId)
+                .collect(java.util.stream.Collectors.toSet());
+
+        List<UserInterest> interests = userInterestRepository.findAllByUserIds(userIds);
+        return personalizedPolicyContextMapper.toContexts(users, interests);
+    }
+
+    public List<PersonalizedPolicyNotificationTarget> findPersonalizedTargets(
+            List<User> users,
+            Map<Long, PolicyRecommendationContext> contexts,
+            List<Policy> newPolicies,
+            Map<Long, List<PolicyRegion>> policyRegionsByPolicyId
+    ) {
+        List<PersonalizedPolicyNotificationTarget> targets = new ArrayList<>();
+        for (User user : users) {
+            //유저 온보딩 정보 조회
+            PolicyRecommendationContext context = contexts.get(user.getId());
+            if (context == null) {
+                continue;
+            }
+
+            List<Policy> regionalCandidates = newPolicies.stream()
+                    .filter(policy -> isAvailableInUserRegion(
+                            user,
+                            policy,
+                            policyRegionsByPolicyId.getOrDefault(policy.getId(), List.of())
+                    ))
+                    .toList();
+            List<Policy> recommendedPolicies = personalizedPolicyRanker.rank(
+                    user,
+                    context,
+                    regionalCandidates,
+                    PERSONALIZED_POLICY_SIZE
+            );
+            if (!recommendedPolicies.isEmpty()) {
+                targets.add(PersonalizedPolicyNotificationTarget.of(
+                        user,
+                        recommendedPolicies
+                ));
+            }
+        }
+        return targets;
+    }
+
+    private Map<Long, List<PolicyRegion>> findPolicyRegionsByPolicyId(
+            Collection<Long> policyIds
+    ) {
+        Map<Long, List<PolicyRegion>> regionsByPolicyId = new HashMap<>();
+        policyRegionRepository.findAllByPolicyIds(policyIds).forEach(policyRegion ->
+                regionsByPolicyId
+                        .computeIfAbsent(
+                                policyRegion.getPolicy().getId(),
+                                key -> new ArrayList<>()
+                        )
+                        .add(policyRegion)
+        );
+        return regionsByPolicyId;
+    }
+
+    private boolean isAvailableInUserRegion(
+            User user,
+            Policy policy,
+            List<PolicyRegion> policyRegions
+    ) {
+        if (policy.isNational()) {
+            return true;
+        }
+        if (user.getSidoCode() == null) {
+            return false;
+        }
+        return policyRegions.stream().anyMatch(policyRegion ->
+                policyRegion.getSidoCode() == user.getSidoCode()
+                        && (
+                                policyRegion.getRegionCode() == null
+                                        || policyRegion.getRegionCode().getSigunguCode()
+                                        .equals(user.getSigunguCode())
+                        )
+        );
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/application/PersonalizedPolicyNotificationService.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/PersonalizedPolicyNotificationService.java
@@ -2,6 +2,7 @@ package com.chungbazi.server.domain.notification.application;
 
 import com.chungbazi.server.domain.notification.application.dto.NotificationKey;
 import com.chungbazi.server.domain.notification.application.dto.PersonalizedPolicyNotificationTarget;
+import com.chungbazi.server.domain.notification.application.event.PersonalizedPolicyNotificationsCreatedEvent;
 import com.chungbazi.server.domain.notification.application.mapper.PersonalizedPolicyContextMapper;
 import com.chungbazi.server.domain.notification.application.mapper.PersonalizedPolicyNotificationMapper;
 import com.chungbazi.server.domain.notification.domain.Notification;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
@@ -47,6 +49,7 @@ public class PersonalizedPolicyNotificationService {
     private final PersonalizedPolicyContextMapper personalizedPolicyContextMapper;
     private final PersonalizedPolicyNotificationMapper personalizedPolicyNotificationMapper;
     private final PersonalizedPolicyRanker personalizedPolicyRanker;
+    private final ApplicationEventPublisher eventPublisher;
 
     public void createPersonalizedPolicyNotifications(NewPoliciesRegisteredEvent event) {
         List<Policy> newPolicies = policyRepository.findAllByIdInAndRecruitmentStatusNot(
@@ -92,6 +95,16 @@ public class PersonalizedPolicyNotificationService {
                     chunkNumber,
                     notifications.size()
             );
+
+            //FCM 알림 발송
+            if (!notifications.isEmpty()) {
+                eventPublisher.publishEvent(PersonalizedPolicyNotificationsCreatedEvent.of(
+                        //알림이 여러 개일 경우 한 개만 FCM 발송
+                        personalizedPolicyNotificationMapper.toRepresentativePushMessages(
+                                notifications
+                        )
+                ));
+            }
 
             cursor = users.getLast().getId();
         }

--- a/src/main/java/com/chungbazi/server/domain/notification/application/PersonalizedPolicyNotificationService.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/PersonalizedPolicyNotificationService.java
@@ -1,7 +1,12 @@
 package com.chungbazi.server.domain.notification.application;
 
+import com.chungbazi.server.domain.notification.application.dto.NotificationKey;
 import com.chungbazi.server.domain.notification.application.dto.PersonalizedPolicyNotificationTarget;
 import com.chungbazi.server.domain.notification.application.mapper.PersonalizedPolicyContextMapper;
+import com.chungbazi.server.domain.notification.application.mapper.PersonalizedPolicyNotificationMapper;
+import com.chungbazi.server.domain.notification.domain.Notification;
+import com.chungbazi.server.domain.notification.domain.repository.NotificationRepository;
+import com.chungbazi.server.domain.notification.domain.type.NotificationType;
 import com.chungbazi.server.domain.policy.application.dto.PolicyRecommendationContext;
 import com.chungbazi.server.domain.policy.application.event.NewPoliciesRegisteredEvent;
 import com.chungbazi.server.domain.policy.application.support.PersonalizedPolicyRanker;
@@ -38,7 +43,9 @@ public class PersonalizedPolicyNotificationService {
     private final UserInterestRepository userInterestRepository;
     private final PolicyRepository policyRepository;
     private final PolicyRegionRepository policyRegionRepository;
+    private final NotificationRepository notificationRepository;
     private final PersonalizedPolicyContextMapper personalizedPolicyContextMapper;
+    private final PersonalizedPolicyNotificationMapper personalizedPolicyNotificationMapper;
     private final PersonalizedPolicyRanker personalizedPolicyRanker;
 
     public void createPersonalizedPolicyNotifications(NewPoliciesRegisteredEvent event) {
@@ -67,12 +74,6 @@ public class PersonalizedPolicyNotificationService {
             }
 
             chunkNumber++;
-            log.info(
-                    "신규 맞춤 정책 알림 사용자 청크 조회 완료. policyCount={}, chunk={}, userCount={}",
-                    event.policyIds().size(),
-                    chunkNumber,
-                    users.size()
-            );
 
             Map<Long, PolicyRecommendationContext> contexts = findRecommendationContexts(users);
 
@@ -84,16 +85,55 @@ public class PersonalizedPolicyNotificationService {
                     policyRegionsByPolicyId
             );
 
+            //알림 저장
+            List<Notification> notifications = savePersonalizedPolicyNotifications(targets);
             log.info(
-                    "신규 맞춤 정책 알림 대상 선별 완료. chunk={}, contextCount={}, targetUserCount={}",
+                    "신규 맞춤 정책 알림 저장 완료. chunk={}, notificationCount={}",
                     chunkNumber,
-                    contexts.size(),
-                    targets.size()
+                    notifications.size()
             );
 
-            // TODO: 선별된 신규 맞춤 정책 알림 저장
             cursor = users.getLast().getId();
         }
+    }
+
+    public List<Notification> savePersonalizedPolicyNotifications(
+            List<PersonalizedPolicyNotificationTarget> targets
+    ) {
+        if (targets.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> userIds = targets.stream()
+                .map(target -> target.user().getId())
+                .collect(java.util.stream.Collectors.toSet());
+
+        Set<Long> policyIds = targets.stream()
+                .flatMap(target -> target.policies().stream())
+                .map(Policy::getId)
+                .collect(java.util.stream.Collectors.toSet());
+
+        Set<NotificationKey> existingNotificationKeys = notificationRepository
+                .findAllByUserIdInAndPolicyIdInAndTypeIn(
+                        userIds,
+                        policyIds,
+                        Set.of(NotificationType.PERSONALIZED_POLICY)
+                ).stream()
+                .map(NotificationKey::from)
+                .collect(java.util.stream.Collectors.toSet());
+
+        List<Notification> notifications = targets.stream()
+                .flatMap(target -> target.policies().stream()
+                        .map(policy -> personalizedPolicyNotificationMapper.toNotification(
+                                target.user(),
+                                policy
+                        )))
+                .filter(notification -> !existingNotificationKeys.contains(
+                        NotificationKey.from(notification)
+                ))
+                .toList();
+
+        return notificationRepository.saveAll(notifications);
     }
 
     public Map<Long, PolicyRecommendationContext> findRecommendationContexts(List<User> users) {

--- a/src/main/java/com/chungbazi/server/domain/notification/application/dto/PersonalizedPolicyNotificationTarget.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/dto/PersonalizedPolicyNotificationTarget.java
@@ -1,0 +1,17 @@
+package com.chungbazi.server.domain.notification.application.dto;
+
+import com.chungbazi.server.domain.policy.domain.entity.Policy;
+import com.chungbazi.server.domain.user.domain.User;
+import java.util.List;
+
+public record PersonalizedPolicyNotificationTarget(
+        User user,
+        List<Policy> policies
+) {
+    public static PersonalizedPolicyNotificationTarget of(
+            User user,
+            List<Policy> policies
+    ) {
+        return new PersonalizedPolicyNotificationTarget(user, List.copyOf(policies));
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/application/event/FirebaseNotificationEventListener.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/event/FirebaseNotificationEventListener.java
@@ -37,4 +37,17 @@ public class FirebaseNotificationEventListener {
             log.error("비동기 FCM 찜한 정책 정보 변경 알림 발송 중 오류 발생", exception);
         }
     }
+
+    @Async(AsyncConfig.NOTIFICATION_EXECUTOR)
+    @TransactionalEventListener(
+            phase = TransactionPhase.AFTER_COMMIT,
+            fallbackExecution = true
+    )
+    public void handle(PersonalizedPolicyNotificationsCreatedEvent event) {
+        try {
+            firebaseNotificationService.sendPersonalizedPolicies(event);
+        } catch (RuntimeException exception) {
+            log.error("비동기 FCM 신규 맞춤 정책 알림 발송 중 오류 발생", exception);
+        }
+    }
 }

--- a/src/main/java/com/chungbazi/server/domain/notification/application/event/NewPoliciesRegisteredEventListener.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/event/NewPoliciesRegisteredEventListener.java
@@ -23,7 +23,7 @@ public class NewPoliciesRegisteredEventListener {
             personalizedPolicyNotificationService.createPersonalizedPolicyNotifications(event);
         } catch (RuntimeException exception) {
             log.error(
-                    "신규 맞춤 정책 알림 대상 사용자 조회 중 오류 발생. policyIds={}",
+                    "신규 맞춤 정책 알림 생성 중 오류 발생. policyIds={}",
                     event.policyIds(),
                     exception
             );

--- a/src/main/java/com/chungbazi/server/domain/notification/application/event/NewPoliciesRegisteredEventListener.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/event/NewPoliciesRegisteredEventListener.java
@@ -1,0 +1,32 @@
+package com.chungbazi.server.domain.notification.application.event;
+
+import com.chungbazi.server.domain.notification.application.PersonalizedPolicyNotificationService;
+import com.chungbazi.server.domain.policy.application.event.NewPoliciesRegisteredEvent;
+import com.chungbazi.server.global.config.AsyncConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NewPoliciesRegisteredEventListener {
+
+    private final PersonalizedPolicyNotificationService personalizedPolicyNotificationService;
+
+    @Async(AsyncConfig.NOTIFICATION_EXECUTOR)
+    @EventListener
+    public void handle(NewPoliciesRegisteredEvent event) {
+        try {
+            personalizedPolicyNotificationService.createPersonalizedPolicyNotifications(event);
+        } catch (RuntimeException exception) {
+            log.error(
+                    "신규 맞춤 정책 알림 대상 사용자 조회 중 오류 발생. policyIds={}",
+                    event.policyIds(),
+                    exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/application/event/PersonalizedPolicyNotificationsCreatedEvent.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/event/PersonalizedPolicyNotificationsCreatedEvent.java
@@ -1,0 +1,14 @@
+package com.chungbazi.server.domain.notification.application.event;
+
+import com.chungbazi.server.domain.notification.application.dto.NotificationPushMessage;
+import java.util.List;
+
+public record PersonalizedPolicyNotificationsCreatedEvent(
+        List<NotificationPushMessage> messages
+) {
+    public static PersonalizedPolicyNotificationsCreatedEvent of(
+            List<NotificationPushMessage> messages
+    ) {
+        return new PersonalizedPolicyNotificationsCreatedEvent(List.copyOf(messages));
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/application/mapper/PersonalizedPolicyContextMapper.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/mapper/PersonalizedPolicyContextMapper.java
@@ -1,0 +1,40 @@
+package com.chungbazi.server.domain.notification.application.mapper;
+
+import com.chungbazi.server.domain.policy.application.dto.PolicyRecommendationContext;
+import com.chungbazi.server.domain.user.domain.User;
+import com.chungbazi.server.domain.user.domain.UserInterest;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PersonalizedPolicyContextMapper {
+
+    public Map<Long, PolicyRecommendationContext> toContexts(
+            List<User> users,
+            List<UserInterest> interests
+    ) {
+        Map<Long, List<UserInterest>> interestsByUserId = groupInterests(interests);
+
+        Map<Long, PolicyRecommendationContext> contexts = new HashMap<>();
+        users.forEach(user -> contexts.put(
+                user.getId(),
+                PolicyRecommendationContext.of(
+                        interestsByUserId.getOrDefault(user.getId(), List.of()),
+                        List.of(),
+                        List.of()
+                )
+        ));
+        return contexts;
+    }
+
+    private Map<Long, List<UserInterest>> groupInterests(List<UserInterest> interests) {
+        Map<Long, List<UserInterest>> interestsByUserId = new HashMap<>();
+        interests.forEach(interest -> interestsByUserId
+                .computeIfAbsent(interest.getUser().getId(), key -> new ArrayList<>())
+                .add(interest));
+        return interestsByUserId;
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/application/mapper/PersonalizedPolicyNotificationMapper.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/mapper/PersonalizedPolicyNotificationMapper.java
@@ -1,0 +1,27 @@
+package com.chungbazi.server.domain.notification.application.mapper;
+
+import com.chungbazi.server.domain.notification.domain.Notification;
+import com.chungbazi.server.domain.notification.domain.type.NotificationCategory;
+import com.chungbazi.server.domain.notification.domain.type.NotificationType;
+import com.chungbazi.server.domain.policy.domain.entity.Policy;
+import com.chungbazi.server.domain.user.domain.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PersonalizedPolicyNotificationMapper {
+
+    private static final String TITLE = "새로운 맞춤 정책이 도착했어요!";
+    private static final String MESSAGE_FORMAT =
+            "%s님에게 잘 맞는 정책을 새롭게 가져왔어요! 지금 바로 어떤 정책인지 확인해보세요.";
+
+    public Notification toNotification(User user, Policy policy) {
+        return Notification.create(
+                user.getId(),
+                NotificationCategory.CHUNGBAZI,
+                NotificationType.PERSONALIZED_POLICY,
+                TITLE,
+                MESSAGE_FORMAT.formatted(user.getName()),
+                policy.getId()
+        );
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/notification/application/mapper/PersonalizedPolicyNotificationMapper.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/application/mapper/PersonalizedPolicyNotificationMapper.java
@@ -1,10 +1,14 @@
 package com.chungbazi.server.domain.notification.application.mapper;
 
+import com.chungbazi.server.domain.notification.application.dto.NotificationPushMessage;
 import com.chungbazi.server.domain.notification.domain.Notification;
 import com.chungbazi.server.domain.notification.domain.type.NotificationCategory;
 import com.chungbazi.server.domain.notification.domain.type.NotificationType;
 import com.chungbazi.server.domain.policy.domain.entity.Policy;
 import com.chungbazi.server.domain.user.domain.User;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -23,5 +27,16 @@ public class PersonalizedPolicyNotificationMapper {
                 MESSAGE_FORMAT.formatted(user.getName()),
                 policy.getId()
         );
+    }
+
+    public List<NotificationPushMessage> toRepresentativePushMessages(
+            List<Notification> notifications
+    ) {
+        Map<Long, NotificationPushMessage> messageByUserId = new LinkedHashMap<>();
+        notifications.forEach(notification -> messageByUserId.putIfAbsent(
+                notification.getUserId(),
+                NotificationPushMessage.from(notification)
+        ));
+        return List.copyOf(messageByUserId.values());
     }
 }

--- a/src/main/java/com/chungbazi/server/domain/notification/domain/repository/NotificationSettingRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/domain/repository/NotificationSettingRepository.java
@@ -26,4 +26,17 @@ public interface NotificationSettingRepository extends JpaRepository<Notificatio
     List<NotificationSetting> findPolicyPushEnabledSettings(
             @Param("userIds") Collection<Long> userIds
     );
+
+    @Query("""
+            SELECT setting
+            FROM NotificationSetting setting
+            JOIN FETCH setting.user user
+            WHERE user.id IN :userIds
+              AND user.deleted = false
+              AND user.fcmToken IS NOT NULL
+              AND setting.chungbaziNotificationEnabled = true
+            """)
+    List<NotificationSetting> findChungbaziPushEnabledSettings(
+            @Param("userIds") Collection<Long> userIds
+    );
 }

--- a/src/main/java/com/chungbazi/server/domain/notification/infrastructure/fcm/FirebaseNotificationService.java
+++ b/src/main/java/com/chungbazi/server/domain/notification/infrastructure/fcm/FirebaseNotificationService.java
@@ -1,6 +1,7 @@
 package com.chungbazi.server.domain.notification.infrastructure.fcm;
 
 import com.chungbazi.server.domain.notification.application.dto.NotificationPushMessage;
+import com.chungbazi.server.domain.notification.application.event.PersonalizedPolicyNotificationsCreatedEvent;
 import com.chungbazi.server.domain.notification.application.event.PolicyReminderNotificationsCreatedEvent;
 import com.chungbazi.server.domain.notification.application.event.PolicyUpdateNotificationsCreatedEvent;
 import com.chungbazi.server.domain.notification.domain.NotificationSetting;
@@ -35,17 +36,28 @@ public class FirebaseNotificationService {
         sendPolicyNotifications(event.messages(), "찜한 정책 정보 변경");
     }
 
+    public void sendPersonalizedPolicies(PersonalizedPolicyNotificationsCreatedEvent event) {
+        Set<Long> userIds = findUserIds(event.messages());
+        List<NotificationSetting> enabledSettings =
+                notificationSettingRepository.findChungbaziPushEnabledSettings(userIds);
+        sendNotifications(event.messages(), enabledSettings, "신규 맞춤 정책");
+    }
+
     private void sendPolicyNotifications(
             List<NotificationPushMessage> messages,
             String notificationName
     ) {
-        Set<Long> userIds = messages.stream()
-                .map(NotificationPushMessage::userId)
-                .collect(Collectors.toSet());
-
+        Set<Long> userIds = findUserIds(messages);
         List<NotificationSetting> enabledSettings =
                 notificationSettingRepository.findPolicyPushEnabledSettings(userIds);
+        sendNotifications(messages, enabledSettings, notificationName);
+    }
 
+    private void sendNotifications(
+            List<NotificationPushMessage> messages,
+            List<NotificationSetting> enabledSettings,
+            String notificationName
+    ) {
         Map<Long, String> fcmTokenByUserId = enabledSettings.stream()
                 .collect(Collectors.toMap(
                         setting -> setting.getUser().getId(),
@@ -76,5 +88,11 @@ public class FirebaseNotificationService {
                 result.failureCount(),
                 result.invalidFcmTokens().size()
         );
+    }
+
+    private Set<Long> findUserIds(List<NotificationPushMessage> messages) {
+        return messages.stream()
+                .map(NotificationPushMessage::userId)
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/application/PersonalizedPolicyService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/PersonalizedPolicyService.java
@@ -1,7 +1,7 @@
 package com.chungbazi.server.domain.policy.application;
 
 import com.chungbazi.server.domain.policy.application.dto.PolicyRecommendationContext;
-import com.chungbazi.server.domain.policy.application.support.PersonalizedPolicyScorer;
+import com.chungbazi.server.domain.policy.application.support.PersonalizedPolicyRanker;
 import com.chungbazi.server.domain.policy.domain.entity.Policy;
 import com.chungbazi.server.domain.policy.domain.repository.PolicyLikeRepository;
 import com.chungbazi.server.domain.policy.domain.repository.RecentViewedPolicyRepository;
@@ -16,11 +16,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.EnumMap;
 import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -29,13 +25,12 @@ public class PersonalizedPolicyService {
 
     private static final int CANDIDATE_SIZE = 300;
     private static final int BEHAVIOR_HISTORY_SIZE = 50;
-    private static final int MAX_SAME_CATEGORY_COUNT = 3;
 
     private final PolicyRepository policyRepository;
     private final UserInterestRepository userInterestRepository;
     private final PolicyLikeRepository policyLikeRepository;
     private final RecentViewedPolicyRepository recentViewedPolicyRepository;
-    private final PersonalizedPolicyScorer scorer;
+    private final PersonalizedPolicyRanker personalizedPolicyRanker;
 
     public List<Policy> getPersonalizedPolicyEntities(User user, int size) {
         // TODO: 추후 캐싱 고려
@@ -62,21 +57,7 @@ public class PersonalizedPolicyService {
                 )
         );
 
-        List<Policy> scoredPolicies = candidates.stream()
-                .filter(policy -> scorer.isEligible(user, policy))
-                .sorted(Comparator
-                        .comparingInt((Policy policy) -> scorer.score(user, context, policy))
-                        .reversed()
-                        .thenComparing(Policy::getRegisteredAt, Comparator.reverseOrder()))
-                .toList();
-
-        // 관심 대분류를 하나만 선택한 경우, 카테고리 다양성 제한 없이 점수순 그대로
-        if (context.interestCategoryCounts().size() <= 1) {
-            return scoredPolicies.stream()
-                    .limit(size)
-                    .toList();
-        }
-        return diversifyByCategory(scoredPolicies, size);
+        return personalizedPolicyRanker.rank(user, context, candidates, size);
     }
 
     public List<Policy> getPersonalizedPolicyEntities(User user, PolicyCategoryType category, int size) {
@@ -112,47 +93,6 @@ public class PersonalizedPolicyService {
                 )
         );
 
-        return candidates.stream()
-                .filter(policy -> scorer.isEligible(user, policy))
-                .sorted(Comparator
-                        .comparingInt((Policy policy) -> scorer.score(user, context, policy))
-                        .reversed()
-                        .thenComparing(Policy::getRegisteredAt, Comparator.reverseOrder()))
-                .limit(size)
-                .toList();
-    }
-
-    private List<Policy> diversifyByCategory(List<Policy> policies, int size) {
-        List<Policy> selectedPolicies = new ArrayList<>();
-        Map<PolicyCategoryType, Integer> selectedCategoryCounts = new EnumMap<>(PolicyCategoryType.class);
-
-        // 관심 대분류가 여러 개인 경우, 같은 대분류가 과도하게 몰리지 않도록 노출 개수 제한
-        for (Policy policy : policies) {
-            PolicyCategoryType category = policy.getCategory();
-            int categoryCount = selectedCategoryCounts.getOrDefault(category, 0);
-
-            if (categoryCount >= MAX_SAME_CATEGORY_COUNT) {
-                continue;
-            }
-            selectedPolicies.add(policy);
-            selectedCategoryCounts.put(category, categoryCount + 1);
-
-            if (selectedPolicies.size() == size) {
-                return selectedPolicies;
-            }
-        }
-
-        // 제한 때문에 목표 개수를 채우지 못한 경우에는 점수순으로 남은 정책 추가
-        for (Policy policy : policies) {
-            if (selectedPolicies.contains(policy)) {
-                continue;
-            }
-            selectedPolicies.add(policy);
-
-            if (selectedPolicies.size() == size) {
-                return selectedPolicies;
-            }
-        }
-        return selectedPolicies;
+        return personalizedPolicyRanker.rank(user, context, candidates, size);
     }
 }

--- a/src/main/java/com/chungbazi/server/domain/policy/application/YouthPolicyPersistenceService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/YouthPolicyPersistenceService.java
@@ -1,5 +1,6 @@
 package com.chungbazi.server.domain.policy.application;
 
+import com.chungbazi.server.domain.policy.application.dto.PolicySyncItemResult;
 import com.chungbazi.server.domain.policy.application.dto.PolicySyncStatus;
 import com.chungbazi.server.domain.policy.application.event.PolicyInformationChangedEvent;
 import com.chungbazi.server.domain.policy.infrastructure.external.youthpolicy.client.dto.YouthPolicyItem;
@@ -36,21 +37,28 @@ public class YouthPolicyPersistenceService {
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
-    public PolicySyncStatus syncPolicy(YouthPolicyItem item) {
+    public PolicySyncItemResult syncPolicy(YouthPolicyItem item) {
         String applyPeriodCode = item.aplyPrdSeCd() == null ? null : item.aplyPrdSeCd().trim();
         String plcyNo = normalizePolicyNumber(item.plcyNo());
         if (plcyNo == null) {
-            return PolicySyncStatus.SKIPPED;
+            return PolicySyncItemResult.of(PolicySyncStatus.SKIPPED, null);
         }
 
         return policyRepository.findByPlcyNo(plcyNo)
-                .map(policy -> syncExistingPolicy(policy, item, applyPeriodCode))
+                .map(policy -> PolicySyncItemResult.of(
+                        syncExistingPolicy(policy, item, applyPeriodCode),
+                        policy.getId()
+                ))
                 .orElseGet(() -> syncNewPolicy(item, plcyNo, applyPeriodCode));
     }
 
-    private PolicySyncStatus syncNewPolicy(YouthPolicyItem item, String plcyNo, String applyPeriodCode) {
+    private PolicySyncItemResult syncNewPolicy(
+            YouthPolicyItem item,
+            String plcyNo,
+            String applyPeriodCode
+    ) {
         if (CLOSED_PERIOD_CODE.equals(applyPeriodCode)) {
-            return PolicySyncStatus.SKIPPED_CLOSED;
+            return PolicySyncItemResult.of(PolicySyncStatus.SKIPPED_CLOSED, null);
         }
 
         PolicyRegionMapping regionMapping = policyRegionMapper.toRegionMapping(item.zipCd());
@@ -63,7 +71,7 @@ public class YouthPolicyPersistenceService {
         policyDetailRepository.save(policyEntityMapper.toPolicyDetail(savedPolicy, item));
         policyRegionRepository.saveAll(policyRegionMapper.toPolicyRegions(savedPolicy, regionMapping));
 
-        return PolicySyncStatus.INSERTED;
+        return PolicySyncItemResult.of(PolicySyncStatus.INSERTED, savedPolicy.getId());
     }
 
     private PolicySyncStatus syncExistingPolicy(Policy policy, YouthPolicyItem item, String applyPeriodCode) {

--- a/src/main/java/com/chungbazi/server/domain/policy/application/YouthPolicySyncService.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/YouthPolicySyncService.java
@@ -1,17 +1,20 @@
 package com.chungbazi.server.domain.policy.application;
 
+import com.chungbazi.server.domain.policy.application.dto.PageSyncResult;
+import com.chungbazi.server.domain.policy.application.dto.PolicySyncItemResult;
+import com.chungbazi.server.domain.policy.application.dto.PolicySyncStatus;
+import com.chungbazi.server.domain.policy.application.dto.SyncResult;
+import com.chungbazi.server.domain.policy.application.event.NewPoliciesRegisteredEvent;
+import com.chungbazi.server.domain.policy.exception.PolicyErrorCode;
+import com.chungbazi.server.domain.policy.exception.PolicyException;
 import com.chungbazi.server.domain.policy.infrastructure.external.youthpolicy.client.YouthPolicyClient;
 import com.chungbazi.server.domain.policy.infrastructure.external.youthpolicy.client.dto.YouthPolicyItem;
 import com.chungbazi.server.domain.policy.infrastructure.external.youthpolicy.client.dto.YouthPolicyListResponse;
+import java.util.ArrayList;
 import java.util.List;
-
-import com.chungbazi.server.domain.policy.application.dto.PageSyncResult;
-import com.chungbazi.server.domain.policy.application.dto.PolicySyncStatus;
-import com.chungbazi.server.domain.policy.application.dto.SyncResult;
-import com.chungbazi.server.domain.policy.exception.PolicyErrorCode;
-import com.chungbazi.server.domain.policy.exception.PolicyException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 
@@ -27,6 +30,7 @@ public class YouthPolicySyncService {
 
     private final YouthPolicyClient youthPolicyClient;
     private final YouthPolicyPersistenceService youthPolicyPersistenceService;
+    private final ApplicationEventPublisher eventPublisher;
 
     public SyncResult syncPolicies() {
         long totalStartTime = System.currentTimeMillis();
@@ -37,6 +41,7 @@ public class YouthPolicySyncService {
         int updatedCount = 0;
         int unchangedCount = 0;
         int skippedCount = 0;
+        List<Long> insertedPolicyIds = new ArrayList<>();
 
         while (true) {
             long fetchStartTime = System.currentTimeMillis();
@@ -64,6 +69,7 @@ public class YouthPolicySyncService {
             updatedCount += pageSyncResult.updatedCount();
             unchangedCount += pageSyncResult.unchangedCount();
             skippedCount += pageSyncResult.skippedCount();
+            insertedPolicyIds.addAll(pageSyncResult.insertedPolicyIds());
 
             log.info(
                     "해당 페이지의 정책 동기화가 완료되었습니다. page={}, fetched={}, inserted={}, updated={}, unchanged={}, skipped={}, invalidRegion={}, invalidCategory={}, fetchElapsedMillis={}, persistElapsedMillis={}",
@@ -87,6 +93,9 @@ public class YouthPolicySyncService {
             pageNum++;
         }
 
+        //새로운 정책 추천 알림 발송
+        publishNewPoliciesRegisteredEvent(insertedPolicyIds);
+
         return new SyncResult(totalFetchedCount, insertedCount, updatedCount, unchangedCount, skippedCount, System.currentTimeMillis() - totalStartTime);
     }
 
@@ -98,13 +107,18 @@ public class YouthPolicySyncService {
         int skippedCount = 0;
         int invalidRegionCount = 0;
         int invalidCategoryCount = 0;
+        List<Long> insertedPolicyIds = new ArrayList<>();
 
         //추후 배치처리?
         for (YouthPolicyItem item : items) {
             try {
-                PolicySyncStatus syncStatus = youthPolicyPersistenceService.syncPolicy(item);
+                PolicySyncItemResult syncResult = youthPolicyPersistenceService.syncPolicy(item);
+                PolicySyncStatus syncStatus = syncResult.status();
                 switch (syncStatus) {
-                    case INSERTED -> insertedCount++;
+                    case INSERTED -> {
+                        insertedCount++;
+                        insertedPolicyIds.add(syncResult.policyId());
+                    }
                     case UPDATED -> updatedCount++;
                     case UNCHANGED -> unchangedCount++;
                     case SKIPPED, SKIPPED_CLOSED -> skippedCount++;
@@ -144,8 +158,16 @@ public class YouthPolicySyncService {
                 unchangedCount,
                 skippedCount,
                 invalidRegionCount,
-                invalidCategoryCount
+                invalidCategoryCount,
+                insertedPolicyIds
         );
+    }
+
+    private void publishNewPoliciesRegisteredEvent(List<Long> insertedPolicyIds) {
+        if (insertedPolicyIds.isEmpty()) {
+            return;
+        }
+        eventPublisher.publishEvent(NewPoliciesRegisteredEvent.of(insertedPolicyIds));
     }
 
     private List<YouthPolicyItem> extractItems(YouthPolicyListResponse response) {

--- a/src/main/java/com/chungbazi/server/domain/policy/application/dto/PageSyncResult.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/dto/PageSyncResult.java
@@ -1,5 +1,7 @@
 package com.chungbazi.server.domain.policy.application.dto;
 
+import java.util.List;
+
 public record PageSyncResult (
             int fetchedCount,
             int insertedCount,
@@ -7,5 +9,10 @@ public record PageSyncResult (
             int unchangedCount,
             int skippedCount,
             int invalidRegionCount,
-            int invalidCategoryCount
-){}
+            int invalidCategoryCount,
+            List<Long> insertedPolicyIds
+) {
+    public PageSyncResult {
+        insertedPolicyIds = List.copyOf(insertedPolicyIds);
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/policy/application/dto/PolicySyncItemResult.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/dto/PolicySyncItemResult.java
@@ -1,0 +1,10 @@
+package com.chungbazi.server.domain.policy.application.dto;
+
+public record PolicySyncItemResult(
+        PolicySyncStatus status,
+        Long policyId
+) {
+    public static PolicySyncItemResult of(PolicySyncStatus status, Long policyId) {
+        return new PolicySyncItemResult(status, policyId);
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/policy/application/event/NewPoliciesRegisteredEvent.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/event/NewPoliciesRegisteredEvent.java
@@ -1,0 +1,11 @@
+package com.chungbazi.server.domain.policy.application.event;
+
+import java.util.List;
+
+public record NewPoliciesRegisteredEvent(
+        List<Long> policyIds
+) {
+    public static NewPoliciesRegisteredEvent of(List<Long> policyIds) {
+        return new NewPoliciesRegisteredEvent(List.copyOf(policyIds));
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/policy/application/support/PersonalizedPolicyRanker.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/application/support/PersonalizedPolicyRanker.java
@@ -1,0 +1,77 @@
+package com.chungbazi.server.domain.policy.application.support;
+
+import com.chungbazi.server.domain.policy.application.dto.PolicyRecommendationContext;
+import com.chungbazi.server.domain.policy.domain.entity.Policy;
+import com.chungbazi.server.domain.policy.domain.type.PolicyCategoryType;
+import com.chungbazi.server.domain.user.domain.User;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PersonalizedPolicyRanker {
+
+    private static final int MAX_SAME_CATEGORY_COUNT = 3;
+
+    private final PersonalizedPolicyScorer scorer;
+
+    public List<Policy> rank(
+            User user,
+            PolicyRecommendationContext context,
+            List<Policy> candidates,
+            int size
+    ) {
+        List<Policy> rankedPolicies = candidates.stream()
+                .filter(policy -> scorer.isEligible(user, policy))
+                .sorted(Comparator
+                        .comparingInt((Policy policy) -> scorer.score(user, context, policy))
+                        .reversed()
+                        .thenComparing(Policy::getRegisteredAt, Comparator.reverseOrder()))
+                .toList();
+
+        if (context.interestCategoryCounts().size() <= 1) {
+            return rankedPolicies.stream()
+                    .limit(size)
+                    .toList();
+        }
+        return diversifyByCategory(rankedPolicies, size);
+    }
+
+    private List<Policy> diversifyByCategory(List<Policy> policies, int size) {
+        List<Policy> selectedPolicies = new ArrayList<>();
+        Map<PolicyCategoryType, Integer> selectedCategoryCounts =
+                new EnumMap<>(PolicyCategoryType.class);
+
+        for (Policy policy : policies) {
+            PolicyCategoryType category = policy.getCategory();
+            int categoryCount = selectedCategoryCounts.getOrDefault(category, 0);
+
+            if (categoryCount >= MAX_SAME_CATEGORY_COUNT) {
+                continue;
+            }
+            selectedPolicies.add(policy);
+            selectedCategoryCounts.put(category, categoryCount + 1);
+
+            if (selectedPolicies.size() == size) {
+                return selectedPolicies;
+            }
+        }
+
+        for (Policy policy : policies) {
+            if (selectedPolicies.contains(policy)) {
+                continue;
+            }
+            selectedPolicies.add(policy);
+
+            if (selectedPolicies.size() == size) {
+                return selectedPolicies;
+            }
+        }
+        return selectedPolicies;
+    }
+}

--- a/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyRegionRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/domain/repository/PolicyRegionRepository.java
@@ -1,12 +1,25 @@
 package com.chungbazi.server.domain.policy.domain.repository;
 
 import com.chungbazi.server.domain.policy.domain.entity.PolicyRegion;
+import java.util.Collection;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PolicyRegionRepository extends JpaRepository<PolicyRegion, Long> {
+
+    @Query("""
+            SELECT policyRegion
+            FROM PolicyRegion policyRegion
+            JOIN FETCH policyRegion.policy policy
+            LEFT JOIN FETCH policyRegion.regionCode
+            WHERE policy.id IN :policyIds
+            """)
+    List<PolicyRegion> findAllByPolicyIds(
+            @Param("policyIds") Collection<Long> policyIds
+    );
 
     @Modifying
     @Query("""

--- a/src/main/java/com/chungbazi/server/domain/policy/domain/repository/policyRepository/PolicyRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/policy/domain/repository/policyRepository/PolicyRepository.java
@@ -21,6 +21,11 @@ public interface PolicyRepository extends JpaRepository<Policy, Long>, PolicyRep
             RecruitmentStatus recruitmentStatus
     );
 
+    List<Policy> findAllByIdInAndRecruitmentStatusNot(
+            Collection<Long> policyIds,
+            RecruitmentStatus recruitmentStatus
+    );
+
     @Modifying
     @Query("""
             UPDATE Policy policy

--- a/src/main/java/com/chungbazi/server/domain/user/infrastructure/UserInterestRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/user/infrastructure/UserInterestRepository.java
@@ -2,11 +2,24 @@ package com.chungbazi.server.domain.user.infrastructure;
 
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.domain.user.domain.UserInterest;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.Collection;
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserInterestRepository extends JpaRepository<UserInterest, Long> {
     List<UserInterest> findAllByUser(User user);
+
+    @Query("""
+            SELECT userInterest
+            FROM UserInterest userInterest
+            JOIN FETCH userInterest.user user
+            WHERE user.id IN :userIds
+            """)
+    List<UserInterest> findAllByUserIds(
+            @Param("userIds") Collection<Long> userIds
+    );
+
     void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/chungbazi/server/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/chungbazi/server/domain/user/infrastructure/UserRepository.java
@@ -2,17 +2,31 @@ package com.chungbazi.server.domain.user.infrastructure;
 
 import com.chungbazi.server.domain.user.domain.User;
 import com.chungbazi.server.domain.user.domain.type.SocialType;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
-import java.util.Optional;
-
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findBySocialTypeAndProviderId(SocialType socialType, String providerId);
+
+    @Query("""
+            SELECT user
+            FROM User user
+            WHERE user.id > :cursor
+              AND user.deleted = false
+              AND user.onboardingCompleted = true
+            ORDER BY user.id ASC
+            """)
+    List<User> findNotificationTargetUsersAfterId(
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
 
     @Modifying(flushAutomatically = true)
     @Query("""

--- a/src/test/java/com/chungbazi/server/domain/notification/application/PersonalizedPolicyTargetSelectionTest.java
+++ b/src/test/java/com/chungbazi/server/domain/notification/application/PersonalizedPolicyTargetSelectionTest.java
@@ -1,0 +1,123 @@
+package com.chungbazi.server.domain.notification.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.chungbazi.server.domain.notification.application.dto.PersonalizedPolicyNotificationTarget;
+import com.chungbazi.server.domain.notification.application.mapper.PersonalizedPolicyContextMapper;
+import com.chungbazi.server.domain.policy.application.dto.PolicyRecommendationContext;
+import com.chungbazi.server.domain.policy.application.support.PersonalizedPolicyRanker;
+import com.chungbazi.server.domain.policy.domain.entity.Policy;
+import com.chungbazi.server.domain.policy.domain.entity.PolicyRegion;
+import com.chungbazi.server.domain.policy.domain.repository.PolicyRegionRepository;
+import com.chungbazi.server.domain.policy.domain.repository.policyRepository.PolicyRepository;
+import com.chungbazi.server.domain.policy.domain.type.SidoCode;
+import com.chungbazi.server.domain.user.domain.User;
+import com.chungbazi.server.domain.user.infrastructure.UserInterestRepository;
+import com.chungbazi.server.domain.user.infrastructure.UserRepository;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PersonalizedPolicyTargetSelectionTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserInterestRepository userInterestRepository;
+
+    @Mock
+    private PolicyRepository policyRepository;
+
+    @Mock
+    private PolicyRegionRepository policyRegionRepository;
+
+    @Mock
+    private PersonalizedPolicyContextMapper personalizedPolicyContextMapper;
+
+    @Mock
+    private PersonalizedPolicyRanker personalizedPolicyRanker;
+
+    @InjectMocks
+    private PersonalizedPolicyNotificationService personalizedPolicyNotificationService;
+
+    @Test
+    void filtersNewPoliciesByUserRegionAndSelectsUpToFiveWithTheExistingRanker() {
+        User seoulUser = user(10L, SidoCode.SEOUL);
+        User busanUser = user(20L, SidoCode.BUSAN);
+        Policy nationalPolicy = policy(100L, true);
+        Policy seoulPolicy = policy(200L, false);
+        PolicyRegion seoulRegion = org.mockito.Mockito.mock(PolicyRegion.class);
+        given(seoulRegion.getSidoCode()).willReturn(SidoCode.SEOUL);
+        given(seoulRegion.getRegionCode()).willReturn(null);
+
+        PolicyRecommendationContext seoulContext = emptyContext();
+        PolicyRecommendationContext busanContext = emptyContext();
+        List<Policy> newPolicies = List.of(nationalPolicy, seoulPolicy);
+        Map<Long, List<PolicyRegion>> regions = Map.of(200L, List.of(seoulRegion));
+
+        given(personalizedPolicyRanker.rank(
+                seoulUser,
+                seoulContext,
+                List.of(nationalPolicy, seoulPolicy),
+                5
+        )).willReturn(List.of(seoulPolicy, nationalPolicy));
+        given(personalizedPolicyRanker.rank(
+                busanUser,
+                busanContext,
+                List.of(nationalPolicy),
+                5
+        )).willReturn(List.of(nationalPolicy));
+
+        List<PersonalizedPolicyNotificationTarget> targets =
+                personalizedPolicyNotificationService.findPersonalizedTargets(
+                        List.of(seoulUser, busanUser),
+                        Map.of(10L, seoulContext, 20L, busanContext),
+                        newPolicies,
+                        regions
+                );
+
+        assertThat(targets).hasSize(2);
+        assertThat(targets.get(0).user()).isEqualTo(seoulUser);
+        assertThat(targets.get(0).policies()).containsExactly(seoulPolicy, nationalPolicy);
+        assertThat(targets.get(1).user()).isEqualTo(busanUser);
+        assertThat(targets.get(1).policies()).containsExactly(nationalPolicy);
+        verify(personalizedPolicyRanker).rank(
+                seoulUser,
+                seoulContext,
+                List.of(nationalPolicy, seoulPolicy),
+                5
+        );
+        verify(personalizedPolicyRanker).rank(
+                busanUser,
+                busanContext,
+                List.of(nationalPolicy),
+                5
+        );
+    }
+
+    private User user(Long id, SidoCode sidoCode) {
+        User user = org.mockito.Mockito.mock(User.class);
+        given(user.getId()).willReturn(id);
+        given(user.getSidoCode()).willReturn(sidoCode);
+        return user;
+    }
+
+    private Policy policy(Long id, boolean national) {
+        Policy policy = org.mockito.Mockito.mock(Policy.class);
+        given(policy.getId()).willReturn(id);
+        given(policy.isNational()).willReturn(national);
+        return policy;
+    }
+
+    private PolicyRecommendationContext emptyContext() {
+        return PolicyRecommendationContext.of(List.of(), List.of(), List.of());
+    }
+}

--- a/src/test/java/com/chungbazi/server/domain/notification/application/PersonalizedPolicyTargetSelectionTest.java
+++ b/src/test/java/com/chungbazi/server/domain/notification/application/PersonalizedPolicyTargetSelectionTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.verify;
 
 import com.chungbazi.server.domain.notification.application.dto.PersonalizedPolicyNotificationTarget;
 import com.chungbazi.server.domain.notification.application.mapper.PersonalizedPolicyContextMapper;
+import com.chungbazi.server.domain.notification.application.mapper.PersonalizedPolicyNotificationMapper;
+import com.chungbazi.server.domain.notification.domain.repository.NotificationRepository;
 import com.chungbazi.server.domain.policy.application.dto.PolicyRecommendationContext;
 import com.chungbazi.server.domain.policy.application.support.PersonalizedPolicyRanker;
 import com.chungbazi.server.domain.policy.domain.entity.Policy;
@@ -40,7 +42,13 @@ class PersonalizedPolicyTargetSelectionTest {
     private PolicyRegionRepository policyRegionRepository;
 
     @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
     private PersonalizedPolicyContextMapper personalizedPolicyContextMapper;
+
+    @Mock
+    private PersonalizedPolicyNotificationMapper personalizedPolicyNotificationMapper;
 
     @Mock
     private PersonalizedPolicyRanker personalizedPolicyRanker;

--- a/src/test/java/com/chungbazi/server/domain/notification/application/mapper/PersonalizedPolicyNotificationMapperTest.java
+++ b/src/test/java/com/chungbazi/server/domain/notification/application/mapper/PersonalizedPolicyNotificationMapperTest.java
@@ -1,0 +1,44 @@
+package com.chungbazi.server.domain.notification.application.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.chungbazi.server.domain.notification.application.dto.NotificationPushMessage;
+import com.chungbazi.server.domain.notification.domain.Notification;
+import com.chungbazi.server.domain.notification.domain.type.NotificationCategory;
+import com.chungbazi.server.domain.notification.domain.type.NotificationType;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PersonalizedPolicyNotificationMapperTest {
+
+    private final PersonalizedPolicyNotificationMapper mapper =
+            new PersonalizedPolicyNotificationMapper();
+
+    @Test
+    void createsOnlyOnePushMessageForMultipleRecommendedPoliciesOfTheSameUser() {
+        Notification firstRankedNotification = notification(1L, 10L);
+        Notification secondRankedNotification = notification(1L, 20L);
+        Notification thirdRankedNotification = notification(1L, 30L);
+
+        List<NotificationPushMessage> messages = mapper.toRepresentativePushMessages(List.of(
+                firstRankedNotification,
+                secondRankedNotification,
+                thirdRankedNotification
+        ));
+
+        assertThat(messages).hasSize(1);
+        assertThat(messages.getFirst().userId()).isEqualTo(1L);
+        assertThat(messages.getFirst().policyId()).isEqualTo(10L);
+    }
+
+    private Notification notification(Long userId, Long policyId) {
+        return Notification.create(
+                userId,
+                NotificationCategory.CHUNGBAZI,
+                NotificationType.PERSONALIZED_POLICY,
+                "새로운 맞춤 정책이 도착했어요!",
+                "새로운 맞춤 정책을 확인해보세요.",
+                policyId
+        );
+    }
+}

--- a/src/test/java/com/chungbazi/server/domain/notification/infrastructure/fcm/FirebaseNotificationServiceTest.java
+++ b/src/test/java/com/chungbazi/server/domain/notification/infrastructure/fcm/FirebaseNotificationServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.chungbazi.server.domain.notification.application.dto.NotificationPushMessage;
+import com.chungbazi.server.domain.notification.application.event.PersonalizedPolicyNotificationsCreatedEvent;
 import com.chungbazi.server.domain.notification.application.event.PolicyReminderNotificationsCreatedEvent;
 import com.chungbazi.server.domain.notification.application.event.PolicyUpdateNotificationsCreatedEvent;
 import com.chungbazi.server.domain.notification.domain.NotificationSetting;
@@ -103,6 +104,30 @@ class FirebaseNotificationServiceTest {
         firebaseNotificationService.sendPolicyUpdates(event);
 
         verify(firebaseNotificationSender).sendAll(List.of(target));
+    }
+
+    @Test
+    void sendsPersonalizedPolicyNotificationToChungbaziPushEnabledUsers() {
+        NotificationPushMessage message = pushMessage(1L, 10L);
+        PersonalizedPolicyNotificationsCreatedEvent event =
+                PersonalizedPolicyNotificationsCreatedEvent.of(List.of(message));
+
+        User enabledUser = org.mockito.Mockito.mock(User.class);
+        NotificationSetting enabledSetting = org.mockito.Mockito.mock(NotificationSetting.class);
+        given(enabledSetting.getUser()).willReturn(enabledUser);
+        given(enabledUser.getId()).willReturn(1L);
+        given(enabledUser.getFcmToken()).willReturn("fcm-token");
+        given(notificationSettingRepository.findChungbaziPushEnabledSettings(Set.of(1L)))
+                .willReturn(List.of(enabledSetting));
+
+        FirebasePushTarget target = FirebasePushTarget.of("fcm-token", message);
+        given(firebaseNotificationSender.sendAll(List.of(target)))
+                .willReturn(FirebasePushResult.of(1, 0, Set.of()));
+
+        firebaseNotificationService.sendPersonalizedPolicies(event);
+
+        verify(firebaseNotificationSender).sendAll(List.of(target));
+        verify(notificationSettingRepository, never()).findPolicyPushEnabledSettings(Set.of(1L));
     }
 
     private NotificationPushMessage pushMessage(Long userId, Long policyId) {

--- a/src/test/java/com/chungbazi/server/domain/policy/application/PersonalizedPolicyRecommendationScenarioTest.java
+++ b/src/test/java/com/chungbazi/server/domain/policy/application/PersonalizedPolicyRecommendationScenarioTest.java
@@ -1,6 +1,7 @@
 package com.chungbazi.server.domain.policy.application;
 
 import com.chungbazi.server.domain.policy.application.support.PersonalizedPolicyScorer;
+import com.chungbazi.server.domain.policy.application.support.PersonalizedPolicyRanker;
 import com.chungbazi.server.domain.policy.application.support.PolicyIncomeMatcher;
 import com.chungbazi.server.domain.policy.domain.entity.Policy;
 import com.chungbazi.server.domain.policy.domain.repository.PolicyLikeRepository;
@@ -60,7 +61,7 @@ public class PersonalizedPolicyRecommendationScenarioTest {
                 userInterestRepository,
                 policyLikeRepository,
                 recentViewedPolicyRepository,
-                scorer
+                new PersonalizedPolicyRanker(scorer)
         );
     }
 

--- a/src/test/java/com/chungbazi/server/domain/policy/application/PersonalizedPolicyServiceTest.java
+++ b/src/test/java/com/chungbazi/server/domain/policy/application/PersonalizedPolicyServiceTest.java
@@ -1,6 +1,7 @@
 package com.chungbazi.server.domain.policy.application;
 
 import com.chungbazi.server.domain.policy.application.dto.PolicyRecommendationContext;
+import com.chungbazi.server.domain.policy.application.support.PersonalizedPolicyRanker;
 import com.chungbazi.server.domain.policy.application.support.PersonalizedPolicyScorer;
 import com.chungbazi.server.domain.policy.domain.entity.Policy;
 import com.chungbazi.server.domain.policy.domain.repository.PolicyLikeRepository;
@@ -54,7 +55,7 @@ public class PersonalizedPolicyServiceTest {
                 userInterestRepository,
                 policyLikeRepository,
                 recentViewedPolicyRepository,
-                scorer
+                new PersonalizedPolicyRanker(scorer)
         );
     }
 

--- a/src/test/java/com/chungbazi/server/domain/policy/application/YouthPolicySyncServiceTest.java
+++ b/src/test/java/com/chungbazi/server/domain/policy/application/YouthPolicySyncServiceTest.java
@@ -1,0 +1,84 @@
+package com.chungbazi.server.domain.policy.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.chungbazi.server.domain.policy.application.dto.PolicySyncItemResult;
+import com.chungbazi.server.domain.policy.application.dto.PolicySyncStatus;
+import com.chungbazi.server.domain.policy.application.dto.SyncResult;
+import com.chungbazi.server.domain.policy.application.event.NewPoliciesRegisteredEvent;
+import com.chungbazi.server.domain.policy.infrastructure.external.youthpolicy.client.YouthPolicyClient;
+import com.chungbazi.server.domain.policy.infrastructure.external.youthpolicy.client.dto.YouthPolicyItem;
+import com.chungbazi.server.domain.policy.infrastructure.external.youthpolicy.client.dto.YouthPolicyListResponse;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class YouthPolicySyncServiceTest {
+
+    @Mock
+    private YouthPolicyClient youthPolicyClient;
+
+    @Mock
+    private YouthPolicyPersistenceService youthPolicyPersistenceService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private YouthPolicySyncService youthPolicySyncService;
+
+    @Test
+    void publishesInsertedPolicyIdsAsOneEventAfterSynchronization() {
+        YouthPolicyItem firstItem = org.mockito.Mockito.mock(YouthPolicyItem.class);
+        YouthPolicyItem secondItem = org.mockito.Mockito.mock(YouthPolicyItem.class);
+        given(youthPolicyClient.fetchPolicies(1, 100))
+                .willReturn(response(List.of(firstItem, secondItem)));
+        given(youthPolicyPersistenceService.syncPolicy(firstItem))
+                .willReturn(PolicySyncItemResult.of(PolicySyncStatus.INSERTED, 10L));
+        given(youthPolicyPersistenceService.syncPolicy(secondItem))
+                .willReturn(PolicySyncItemResult.of(PolicySyncStatus.UPDATED, 20L));
+
+        SyncResult result = youthPolicySyncService.syncPolicies();
+
+        assertThat(result.insertedCount()).isEqualTo(1);
+        assertThat(result.updatedCount()).isEqualTo(1);
+
+        ArgumentCaptor<NewPoliciesRegisteredEvent> eventCaptor =
+                ArgumentCaptor.forClass(NewPoliciesRegisteredEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().policyIds()).containsExactly(10L);
+    }
+
+    @Test
+    void doesNotPublishEventWhenNoPolicyWasInserted() {
+        YouthPolicyItem item = org.mockito.Mockito.mock(YouthPolicyItem.class);
+        given(youthPolicyClient.fetchPolicies(1, 100))
+                .willReturn(response(List.of(item)));
+        given(youthPolicyPersistenceService.syncPolicy(item))
+                .willReturn(PolicySyncItemResult.of(PolicySyncStatus.UNCHANGED, 10L));
+
+        youthPolicySyncService.syncPolicies();
+
+        verify(eventPublisher, never()).publishEvent(org.mockito.ArgumentMatchers.any());
+    }
+
+    private YouthPolicyListResponse response(List<YouthPolicyItem> items) {
+        return new YouthPolicyListResponse(
+                0,
+                "success",
+                new YouthPolicyListResponse.Result(
+                        new YouthPolicyListResponse.Paging(items.size(), 1, 100),
+                        items
+                )
+        );
+    }
+}

--- a/src/test/java/com/chungbazi/server/domain/policy/application/support/PersonalizedPolicyScorerTest.java
+++ b/src/test/java/com/chungbazi/server/domain/policy/application/support/PersonalizedPolicyScorerTest.java
@@ -24,7 +24,7 @@ public class PersonalizedPolicyScorerTest {
 
     @BeforeEach
     void setUp() {
-        scorer = new PersonalizedPolicyScorer();
+        scorer = new PersonalizedPolicyScorer(new PolicyIncomeMatcher());
     }
 
     @Test


### PR DESCRIPTION
## 🔗 연관된 이슈
- #56 

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [x] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 정책 동기화 완료 후 신규 정책 등록 이벤트 발행
- 성능을 고려하여 사용자를 청크 단위로 조회해 신규 맞춤 정책 대상 선별
- 기존 추천 로직을 활용해 사용자별 최대 5개 정책 추천 (FCM 발송은 사용자별 대표 알림 1건만)
- 추천 정책별 알림 저장 및 중복 생성 방지

## 📸 스크린샷
>

## ✅ 체크리스트
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 테스트 시 사용한 로그를 삭제했습니다.

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 대상 사용자 조회 및 맞춤 정책 선별 흐름이 적절한지 확인 부탁드립니다!
- 기존 추천 로직을 재활용하면서, 알림 대상 선별과 온보딩을 통한 추천 대상 선별 로직이 조금 달라 추천 로직만 컴포넌트로 분리했습니다. 해당 부분 문제없는지 점검 부탁드립니다!
- 정책별 알림은 저장하되 사용자별 FCM은 1건만 발송하는 구조를 확인 부탁드립니다!
- 사용자별 찜 및 최근 조회 이력은 신규 정책이라 반영할 필요가 없을 거 같아 추천 시 반영하지 않았습니다 이 부분 확인부탁드립니다!

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

> - **P1:** 꼭 반영해주세요 (Comment)
> - **P2:** 적극적으로 고려해주세요 (Comment)
> - **P3:** 웬만하면 반영해 주세요 (Comment)
> - **P4:** 반영해도 좋고 넘어가도 좋습니다 (Approve)
> - **P5:** 그냥 사소한 의견입니다 (Approve)

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 신규 정책 등록 시 사용자의 관심사와 지역을 반영한 맞춤 정책 알림을 자동 생성합니다.
  - 사용자별 최대 5개 정책을 추천하며, 전국 정책과 지역별 정책을 구분해 제공합니다.
  - 기존 알림과 중복되지 않는 알림만 저장하고, 푸시 알림을 자동 발송합니다.
  - 정책 추천 시 카테고리 편중을 줄이고 다양한 정책을 우선 제공합니다.

- **개선**
  - 정책 동기화 결과에 신규 정책 정보를 포함해 알림 처리 흐름을 강화했습니다.
  - 알림 발송 대상과 푸시 활성 상태를 더욱 정확하게 확인합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->